### PR TITLE
TextureInitializationGroup

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,6 +1,7 @@
 
 use std::io::{Result as IOResult, BufReader, Error as IOError, ErrorKind, Cursor};
 use std::io::prelude::{Read, Seek};
+use super::PixelFormat;
 
 pub trait PlatformAssetLoader {
     type Asset: Read + Seek;
@@ -52,6 +53,17 @@ impl DecodedPixelData {
         let pixels = decoder.read_image()?;
         
         Ok(DecodedPixelData { pixels, size: math::Vector2(w as _, h as _), color, stride: stride as _ })
+    }
+    pub fn format(&self) -> PixelFormat
+    {
+        match self.color
+        {
+            image::ColorType::RGB(8) => PixelFormat::RGB24,
+            image::ColorType::RGBA(8) => PixelFormat::RGBA32,
+            image::ColorType::BGR(8) => PixelFormat::BGR24,
+            image::ColorType::BGRA(8) => PixelFormat::BGRA32,
+            _ => panic!("unsupported color type: {:?}", self.color)
+        }
     }
 
     pub fn u8_pixels(&self) -> &[u8] { &self.pixels }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -241,3 +241,14 @@ impl Deref for Texture2D {
     type Target = br::ImageView;
     fn deref(&self) -> &br::ImageView { &self.0 }
 }
+
+/// Low Dynamic Range(8bit colors) image asset
+pub trait LDRImageAsset
+{
+    fn into_pixel_data_info(self) -> DecodedPixelData;
+}
+impl LDRImageAsset for BMP { fn into_pixel_data_info(self) -> DecodedPixelData { self.0 } }
+impl LDRImageAsset for PNG { fn into_pixel_data_info(self) -> DecodedPixelData { self.0 } }
+impl LDRImageAsset for TGA { fn into_pixel_data_info(self) -> DecodedPixelData { self.0 } }
+impl LDRImageAsset for TIFF { fn into_pixel_data_info(self) -> DecodedPixelData { self.0 } }
+impl LDRImageAsset for WebP { fn into_pixel_data_info(self) -> DecodedPixelData { self.0 } }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -210,29 +210,53 @@ impl br::VkHandle for Image {
 #[derive(Clone, Copy)] #[repr(i32)]
 pub enum PixelFormat {
     RGBA32 = br::vk::VK_FORMAT_R8G8B8A8_UNORM,
-    BGRA32 = br::vk::VK_FORMAT_B8G8R8A8_UNORM
+    BGRA32 = br::vk::VK_FORMAT_B8G8R8A8_UNORM,
+    RGB24 = br::vk::VK_FORMAT_R8G8B8_UNORM,
+    BGR24 = br::vk::VK_FORMAT_B8G8R8_UNORM
 }
 impl PixelFormat {
     /// Bits per pixel for each format enums
-    pub fn bpp(&self) -> usize {
-        match *self {
-            PixelFormat::RGBA32 | PixelFormat::BGRA32 => 32
+    pub fn bpp(self) -> usize
+    {
+        match self
+        {
+            PixelFormat::RGBA32 | PixelFormat::BGRA32 => 32,
+            PixelFormat::RGB24 | PixelFormat::BGR24 => 24
         }
     }
 }
 
 pub struct Texture2D(br::ImageView, Image);
-impl Texture2D {
+impl Texture2D
+{
     pub fn init(g: &br::Device, size: &math::Vector2<u32>, format: PixelFormat, prealloc: &mut BufferPrealloc)
-            -> br::Result<(br::Image, u64)> {
+        -> br::Result<(br::Image, u64)>
+    {
         let idesc = br::ImageDesc::new(size, format as _, br::ImageUsage::SAMPLED.transfer_dest(),
             br::ImageLayout::Preinitialized);
         let pixels_stg = prealloc.add(BufferContent::Raw((size.x() * size.y()) as u64 * (format.bpp() >> 3) as u64));
         return idesc.create(g).map(|o| (o, pixels_stg));
     }
-    pub fn new(img: Image) -> br::Result<Self> {
-        return img.create_view(None, None, &br::ComponentMapping::default(), &br::ImageSubresourceRange::color(0, 0))
-            .map(|v| Texture2D(v, img))
+    pub fn new(img: Image) -> br::Result<Self>
+    {
+        let (fmt, cmap) = match img.format()
+        {
+            PixelFormat::RGB24 =>
+            (
+                Some(PixelFormat::RGBA32 as _),
+                br::ComponentMapping(br::ComponentSwizzle::Identity, br::ComponentSwizzle::Identity,
+                    br::ComponentSwizzle::Identity, br::ComponentSwizzle::One)
+            ),
+            PixelFormat::BGR24 =>
+            (
+                Some(PixelFormat::BGRA32 as _),
+                br::ComponentMapping(br::ComponentSwizzle::Identity, br::ComponentSwizzle::Identity,
+                    br::ComponentSwizzle::Identity, br::ComponentSwizzle::One)
+            ),
+            _ => (None, br::ComponentMapping::default())
+        };
+
+        img.create_view(fmt, None, &cmap, &br::ImageSubresourceRange::color(0, 0)).map(|v| Texture2D(v, img))
     }
 
     pub fn image(&self) -> &Image { &self.1 }
@@ -252,3 +276,77 @@ impl LDRImageAsset for PNG { fn into_pixel_data_info(self) -> DecodedPixelData {
 impl LDRImageAsset for TGA { fn into_pixel_data_info(self) -> DecodedPixelData { self.0 } }
 impl LDRImageAsset for TIFF { fn into_pixel_data_info(self) -> DecodedPixelData { self.0 } }
 impl LDRImageAsset for WebP { fn into_pixel_data_info(self) -> DecodedPixelData { self.0 } }
+
+/// Stg1. Group what textures are being initialized
+pub struct TextureInitializationGroup<'g>(&'g br::Device, Vec<DecodedPixelData>);
+/// Stg2. Describes where textures are being staged
+pub struct TexturePreallocatedGroup(Vec<(DecodedPixelData, u64)>, Vec<br::Image>);
+/// Stg3. Describes where textures are being staged, allocated and bound their memory
+pub struct TextureInstantiatedGroup(Vec<(DecodedPixelData, u64)>, Vec<Texture2D>);
+
+impl<'g> TextureInitializationGroup<'g>
+{
+    pub fn new(device: &'g br::Device) -> Self { TextureInitializationGroup(device, Vec::new()) }
+    pub fn add<A: LDRImageAsset>(&mut self, asset: A) -> usize
+    {
+        let index = self.1.len();
+        self.1.push(asset.into_pixel_data_info());
+        return index;
+    }
+    pub fn prealloc(self, prealloc: &mut BufferPrealloc) -> br::Result<TexturePreallocatedGroup>
+    {
+        let (mut images, mut stage_info) = (Vec::with_capacity(self.1.len()), Vec::with_capacity(self.1.len()));
+        for pd in self.1 {
+            let (o, offs) = Texture2D::init(self.0, &pd.size, pd.format(), prealloc)?;
+            images.push(o); stage_info.push((pd, offs));
+        }
+        return Ok(TexturePreallocatedGroup(stage_info, images));
+    }
+}
+impl TexturePreallocatedGroup
+{
+    pub fn alloc_and_instantiate(self, mut badget: MemoryBadget)
+        -> br::Result<(TextureInstantiatedGroup, Vec<MemoryBoundResource>)>
+    {
+        let img_count = self.1.len();
+        for isrc in self.1 { badget.add(isrc); }
+        let mut resources = badget.alloc()?;
+        let textures = resources.drain(resources.len() - img_count ..)
+            .map(|r| Texture2D::new(r.unwrap_image())).collect::<Result<Vec<_>, _>>()?;
+
+        return Ok((TextureInstantiatedGroup(self.0, textures), resources));
+    }
+}
+impl TextureInstantiatedGroup
+{
+    /// Copy texture pixels into a staging buffer.
+    pub fn stage_data(&self, mr: &br::MappedMemoryRange)
+    {
+        trace!("Staging Texture Data...");
+        for &(ref pd, offs) in &self.0 {
+            let s = unsafe
+            {
+                mr.slice_mut(offs as _, (pd.size.x() * pd.size.y()) as usize * (pd.format().bpp() >> 3) as usize)
+            };
+            s.copy_from_slice(pd.u8_pixels());
+        }
+    }
+    /// Push transferring operations into a batcher.
+    pub fn copy_from_stage_batches(&self, tb: &mut TransferBatch, stgbuf: &Buffer)
+    {
+        for (t, &(_, offs)) in self.1.iter().zip(self.0.iter())
+        {
+            tb.init_image_from(t.image(), (stgbuf, offs));
+            tb.add_image_graphics_ready(br::PipelineStageFlags::FRAGMENT_SHADER, t.image(),
+                br::ImageLayout::ShaderReadOnlyOpt);
+        }
+    }
+
+    /// Returns a list of Texture2D.
+    pub fn into_textures(self) -> Vec<Texture2D> { return self.1; }
+}
+impl Deref for TextureInstantiatedGroup
+{
+    type Target = [Texture2D];
+    fn deref(&self) -> &[Texture2D] { &self.1 }
+}


### PR DESCRIPTION
#38 からの切り出し

複数テクスチャオブジェクトの一括メモリ管理、一括初期化などを行ってくれる構造体3つを追加する