### PR TITLE
レンダリング修正

### DIFF
--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -203,7 +203,7 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL>
     fn update(&mut self, e: &peridot::Engine<Self, PL>, on_backbuffer_of: u32, delta_time: Duration)
             -> (Option<br::SubmissionBatch>, br::SubmissionBatch) {
         let dtsec = delta_time.as_secs() as f32 + delta_time.subsec_micros() as f32 / 1000_0000.0;
-        self.rot += (dtsec * 60.0 * 1.0).to_radians();
+        self.rot += dtsec * 15.0;
         self.buffers.mut_buffer.0.guard_map(size_of::<Matrix4F32>() as _, |m| unsafe
         {
             m.get_mut::<Uniform>(self.mut_uniform_offset as _).object

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -201,10 +201,11 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL>
     }
 
     fn update(&mut self, e: &peridot::Engine<Self, PL>, on_backbuffer_of: u32, delta_time: Duration)
-            -> (Option<br::SubmissionBatch>, br::SubmissionBatch) {
+        -> (Option<br::SubmissionBatch>, br::SubmissionBatch)
+    {
         let dtsec = delta_time.as_secs() as f32 + delta_time.subsec_micros() as f32 / 1000_0000.0;
         self.rot += dtsec * 15.0;
-        self.buffers.mut_buffer.0.guard_map(size_of::<Matrix4F32>() as _, |m| unsafe
+        self.buffers.mut_buffer.0.guard_map(self.mut_uniform_offset + size_of::<Uniform>() as u64, |m| unsafe
         {
             m.get_mut::<Uniform>(self.mut_uniform_offset as _).object
                 = Quaternion::new(self.rot, Vector3F32::up()).into();

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -5,9 +5,9 @@ use peridot::math::{
     Vector3F32, Vector3, Vector2F32, Vector2, Camera, ProjectionMethod, Matrix4F32, Quaternion, Matrix4, Vector4, One
 };
 use peridot::{
-    CommandBundle, CBSubmissionType, TransferBatch, MemoryBadget, BufferPrealloc, BufferContent,
+    CommandBundle, CBSubmissionType, TransferBatch, BufferPrealloc, BufferContent,
     SubpassDependencyTemplates, PvpShaderModules, DescriptorSetUpdateBatch, LayoutedPipeline,
-    TextureInitializationGroup, Texture2D, Buffer,
+    TextureInitializationGroup, Buffer,
     FixedMemory, FixedBufferInitializer
 };
 use std::borrow::Cow;

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -258,9 +258,10 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
         }
     }
 
-    fn update(&mut self, e: &peridot::Engine<Self, PL>, on_backbuffer_of: u32)
+    fn update(&mut self, e: &peridot::Engine<Self, PL>, on_backbuffer_of: u32, delta_time: Duration)
             -> (Option<br::SubmissionBatch>, br::SubmissionBatch) {
-        self.rot += 1.0f32.to_radians();
+        let dtsec = delta_time.as_secs() as f32 + delta_time.subsec_micros() as f32 / 1000_0000.0;
+        self.rot += (dtsec * 60.0 * 1.0).to_radians();
         self.buffers.mut_buffer.0.guard_map(size_of::<Matrix4F32>() as _, |m| unsafe
         {
             m.get_mut::<Uniform>(self.mut_uniform_offset as _).object

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -6,20 +6,114 @@ use peridot::math::{
 };
 use peridot::{
     CommandBundle, CBSubmissionType, TransferBatch, MemoryBadget, BufferPrealloc, BufferContent,
-    SubpassDependencyTemplates, PvpShaderModules, DescriptorSetUpdateBatch, LayoutedPipeline
+    SubpassDependencyTemplates, PvpShaderModules, DescriptorSetUpdateBatch, LayoutedPipeline,
+    TextureInitializationGroup, Texture2D, Buffer
 };
 use std::borrow::Cow;
 use std::rc::Rc;
 use std::mem::size_of;
+use std::ops::Range;
+
+pub trait FixedBufferInitializer
+{
+    fn stage_data(&mut self, m: &br::MappedMemoryRange);
+    fn buffer_graphics_ready(&self, tfb: &mut TransferBatch, buffer: &Buffer, buffer_range: Range<u64>);
+}
+pub struct FixedBuffer
+{
+    buffer: (Buffer, u64), mut_buffer: (Buffer, u64), mut_buffer_placement: u64,
+    textures: Vec<Texture2D>
+}
+impl FixedBuffer
+{
+    pub fn new<'g, I: FixedBufferInitializer + ?Sized>(g: &'g peridot::Graphics,
+        mut prealloc: BufferPrealloc<'g>, mut prealloc_mut: BufferPrealloc<'g>,
+        textures: TextureInitializationGroup<'g>,
+        initializer: &mut I, tfb: &mut TransferBatch)
+        -> br::Result<Self>
+    {
+        let mut p_bufferdata_prealloc = prealloc.clone();
+        let mut_buffer = prealloc_mut.build_upload()?;
+        let imm_buffer_size = p_bufferdata_prealloc.total_size();
+        let mut_buffer_placement = p_bufferdata_prealloc.merge(&prealloc_mut);
+        let buffer = p_bufferdata_prealloc.build_transferred()?;
+
+        let stg_buffer_size = prealloc.total_size();
+        let tex_preallocs = textures.prealloc(&mut prealloc)?;
+        let stg_buffer_fullsize = prealloc.total_size();
+        let stg_buffer = prealloc.build_upload()?;
+
+        let mut mb = MemoryBadget::new(g);
+        mb.add(buffer);
+        let (tex, mut bres) = tex_preallocs.alloc_and_instantiate(mb)?;
+        let buffer = bres.pop().expect("objectless").unwrap_buffer();
+        let mut mb_stg = MemoryBadget::new(g);
+        mb_stg.add(stg_buffer);
+        let stg_buffer = mb_stg.alloc_upload()?.pop().expect("objectless").unwrap_buffer();
+        let mut mb_mut = MemoryBadget::new(g);
+        mb_mut.add(mut_buffer);
+        let mut_buffer = mb_mut.alloc_upload()?.pop().expect("objectless").unwrap_buffer();
+
+        stg_buffer.guard_map(stg_buffer_size, |m| { tex.stage_data(m); initializer.stage_data(m); })?;
+
+        tex.copy_from_stage_batches(tfb, &stg_buffer);
+        tfb.add_mirroring_buffer(&stg_buffer, &buffer, 0, stg_buffer_size as _);
+        initializer.buffer_graphics_ready(tfb, &buffer, 0 .. imm_buffer_size as _);
+
+        Ok(FixedBuffer
+        {
+            buffer: (buffer, imm_buffer_size), mut_buffer: (mut_buffer, prealloc_mut.total_size()),
+            mut_buffer_placement,
+            textures: tex.into_textures()
+        })
+    }
+
+    pub fn range_in_mut_buffer<T>(&self, r: Range<T>) -> Range<T> where
+        T: std::ops::Add<Output = T> + std::convert::TryFrom<u64> + Copy
+    {
+        match T::try_from(self.mut_buffer_placement)
+        {
+            Ok(p) => r.start + p .. r.end + p,
+            Err(_) => panic!("Overflowing Placement offset")
+        }
+    }
+}
+
+pub struct IPFixedBufferInitializer
+{
+    vertices_offset: u64
+}
+impl FixedBufferInitializer for IPFixedBufferInitializer
+{
+    fn stage_data(&mut self, m: &br::MappedMemoryRange)
+    {
+        unsafe
+        {
+            m.slice_mut(self.vertices_offset as _, 4).clone_from_slice(&[
+                UVVert { pos: Vector3(-1.0, -1.0, 0.0), uv: Vector2(0.0, 0.0) },
+                UVVert { pos: Vector3( 1.0, -1.0, 0.0), uv: Vector2(1.0, 0.0) },
+                UVVert { pos: Vector3(-1.0,  1.0, 0.0), uv: Vector2(0.0, 1.0) },
+                UVVert { pos: Vector3( 1.0,  1.0, 0.0), uv: Vector2(1.0, 1.0) }
+            ]);
+        }
+    }
+    fn buffer_graphics_ready(&self, tfb: &mut TransferBatch, buffer: &Buffer, buffer_range: Range<u64>)
+    {
+        tfb.add_buffer_graphics_ready(br::PipelineStageFlags::VERTEX_INPUT.vertex_shader(), buffer,
+            buffer_range.start as _ .. buffer_range.end as _,
+            br::AccessFlags::UNIFORM_READ | br::AccessFlags::VERTEX_ATTRIBUTE_READ);
+    }
+}
 
 pub struct Game<PL: peridot::NativeLinker> {
-    ph: PhantomData<*const PL>, buffer: peridot::Buffer, rot: f32, stg_buffer: peridot::Buffer,
+    ph: PhantomData<*const PL>, rot: f32,
     render_cb: peridot::CommandBundle, update_cb: peridot::CommandBundle,
     renderpass: br::RenderPass, framebuffers: Vec<br::Framebuffer>,
     gp_main: LayoutedPipeline,
     descriptor: (br::DescriptorSetLayout, br::DescriptorPool, Vec<br::vk::VkDescriptorSet>),
-    _res: (peridot::Texture2D, br::Sampler),
-    vertices_offset: u64
+    _sampler: br::Sampler,
+    vertices_offset: u64,
+    buffers: FixedBuffer, mut_uniform_offset: u64
 }
 impl<PL: peridot::NativeLinker> Game<PL> {
     pub const NAME: &'static str = "Peridot Examples - ImagePlane";
@@ -28,6 +122,7 @@ impl<PL: peridot::NativeLinker> Game<PL> {
 impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
     fn init(e: &peridot::Engine<Self, PL>) -> Self {
         let screen_size: br::Extent3D = e.backbuffers()[0].size().clone().into();
+        let screen_aspect = screen_size.1 as f32 / screen_size.0 as f32;
 
         let image_data: peridot::PNG = e.load("images.example").expect("No image found");
         println!("Image: {}x{}", image_data.0.size.x(), image_data.0.size.y());
@@ -35,80 +130,62 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
         println!("ImageStride: {} bytes", image_data.0.stride);
 
         let mut bp = BufferPrealloc::new(e.graphics());
-        let uniform_offset = bp.add(BufferContent::uniform::<Uniform>());
         let vertices_offset = bp.add(BufferContent::vertex::<[UVVert; 4]>());
-        let buffer = bp.build_transferred().expect("Alloc Buffer");
-        let buffer_size = bp.total_size();
+        let mut fm_init = IPFixedBufferInitializer
+        {
+            vertices_offset
+        };
 
-        let (image, image_stg_offs) = peridot::Texture2D::init(&e.graphics(),
-            &image_data.0.size, peridot::PixelFormat::RGBA32, &mut bp)
-            .expect("Failed to init for texture object");
-        println!("imgofs: {}", image_stg_offs);
+        let mut ti = TextureInitializationGroup::new(e.graphics());
+        ti.add(image_data);
 
-        let stg_buffer = bp.build_upload().expect("Alloc StgBuffer");
-        let mut mb = MemoryBadget::new(e.graphics());
-        mb.add(buffer);
-        mb.add(image);
-        let mut objects = mb.alloc().expect("Alloc Mem");
-        let image = peridot::Texture2D::new(objects.pop().expect("missing image").unwrap_image())
-            .expect("Creating Texture2D");
-        let buffer = objects.pop().expect("missing buffer").unwrap_buffer();
-        let mut stg_mb = MemoryBadget::new(e.graphics());
-        stg_mb.add(stg_buffer);
-        let stg_buffer = stg_mb.alloc_upload().expect("Alloc StgMem").pop().expect("missing buffer").unwrap_buffer();
+        let mut bp_mut = BufferPrealloc::new(e.graphics());
+        let mut_uniform_offset = bp_mut.add(BufferContent::uniform::<Uniform>());
 
+        let mut tfb = TransferBatch::new();
+        let buffers = FixedBuffer::new(e.graphics(), bp, bp_mut, ti, &mut fm_init, &mut tfb)
+            .expect("Alloc FixedBuffers");
+        
         let cam = Camera {
             projection: ProjectionMethod::Perspective { fov: 75.0f32.to_radians() },
             position: Vector3(-3.0, 0.0, -3.0), rotation: Quaternion::new(45.0f32.to_radians(), Vector3::up()),
             // position: Vector3(0.0, 0.0, -3.0), rotation: Quaternion::ONE,
             depth_range: 1.0 .. 10.0
         };
-        stg_buffer.guard_map(bp.total_size(), |r| unsafe {
+        buffers.mut_buffer.0.guard_map(buffers.mut_buffer.1, |m| unsafe
+        {
             let (v, p) = cam.matrixes();
-            let aspect = Matrix4::scale(Vector4(screen_size.1 as f32 / screen_size.0 as f32, 1.0, 1.0, 1.0));
+            let aspect = Matrix4::scale(Vector4(screen_aspect, 1.0, 1.0, 1.0));
             let vp = aspect * p * v;
-            *r.get_mut(uniform_offset as _) = Uniform { camera: vp, object: Matrix4::ONE };
-            r.slice_mut(vertices_offset as _, 4).clone_from_slice(&[
-                UVVert { pos: Vector3(-1.0, -1.0, 0.0), uv: Vector2(0.0, 0.0) },
-                UVVert { pos: Vector3( 1.0, -1.0, 0.0), uv: Vector2(1.0, 0.0) },
-                UVVert { pos: Vector3(-1.0,  1.0, 0.0), uv: Vector2(0.0, 1.0) },
-                UVVert { pos: Vector3( 1.0,  1.0, 0.0), uv: Vector2(1.0, 1.0) }
-            ]);
-            r.slice_mut(image_stg_offs as _, image_data.0.u8_pixels().len()).copy_from_slice(image_data.0.u8_pixels());
-        }).expect("Failure in constructing initial data");
+            *m.get_mut(mut_uniform_offset as _) = Uniform
+            {
+                camera: vp, object: Matrix4::ONE
+            };
+        }).expect("Staging MutBuffer");
+        let mut tfb_mut = TransferBatch::new();
+        let dst_update_range = buffers.mut_buffer_placement ..
+            buffers.mut_buffer_placement + size_of::<Uniform>() as u64;
+        tfb.add_copying_buffer((&buffers.mut_buffer.0, mut_uniform_offset),
+            (&buffers.buffer.0, dst_update_range.start), size_of::<Uniform>() as _);
+        tfb_mut.add_copying_buffer((&buffers.mut_buffer.0, mut_uniform_offset),
+            (&buffers.buffer.0, dst_update_range.start), size_of::<Uniform>() as _);
+        tfb.add_buffer_graphics_ready(br::PipelineStageFlags::VERTEX_SHADER, &buffers.buffer.0,
+            dst_update_range.clone(), br::AccessFlags::UNIFORM_READ);
+        tfb_mut.add_buffer_graphics_ready(br::PipelineStageFlags::VERTEX_SHADER, &buffers.buffer.0,
+            dst_update_range, br::AccessFlags::UNIFORM_READ);
 
-        e.submit_commands(|r| {
-            let mut tfb = TransferBatch::new();
-            tfb.add_mirroring_buffer(&stg_buffer, &buffer, 0, buffer_size as _);
-            tfb.add_buffer_graphics_ready(br::PipelineStageFlags::VERTEX_INPUT.vertex_shader(), &buffer,
-                0 .. buffer_size as _, br::AccessFlags::UNIFORM_READ | br::AccessFlags::VERTEX_ATTRIBUTE_READ);
-            tfb.init_image_from(image.image(), (&stg_buffer, image_stg_offs));
-            tfb.add_image_graphics_ready(br::PipelineStageFlags::FRAGMENT_SHADER, image.image(),
-                br::ImageLayout::ShaderReadOnlyOpt);
+        e.submit_commands(|r|
+        {
             tfb.sink_transfer_commands(r);
             tfb.sink_graphics_ready_commands(r);
         }).expect("Failure in transferring initial data");
-
-        let mut bp_stg2 = BufferPrealloc::new(e.graphics());
-        bp_stg2.add(BufferContent::Uniform((size_of::<Matrix4F32>() * e.backbuffers().len()) as _));
-        let stg_buffer2 = bp_stg2.build_upload().expect("Alloc StgBuffer2");
-        let mut mb_stg2 = MemoryBadget::new(e.graphics());
-        mb_stg2.add(stg_buffer2);
-        let stg_buffer2 = mb_stg2.alloc_upload().expect("Alloc StgMem2").pop().expect("missing buffer").unwrap_buffer();
-        let update_cb = CommandBundle::new(&e.graphics(), CBSubmissionType::Graphics, e.backbuffers().len())
+        
+        let update_cb = CommandBundle::new(&e.graphics(), CBSubmissionType::Graphics, 1)
             .expect("Alloc UpdateCB");
-        for (n, cb) in update_cb.iter().enumerate()
         {
-            let mut rec = cb.begin().expect("Begin UpdateCmdRec");
-            let mut tfb = TransferBatch::new();
-            let update_range = uniform_offset + size_of::<Matrix4F32>() as u64 ..
-                uniform_offset + size_of::<Matrix4F32>() as u64 + size_of::<Matrix4F32>() as u64;
-            tfb.add_copying_buffer((&stg_buffer2, (size_of::<Matrix4F32>() * n) as u64),
-                (&buffer, update_range.start), size_of::<Matrix4F32>() as _);
-            tfb.add_buffer_graphics_ready(br::PipelineStageFlags::VERTEX_SHADER, &buffer,
-                update_range, br::AccessFlags::UNIFORM_READ);
-            tfb.sink_transfer_commands(&mut rec);
-            tfb.sink_graphics_ready_commands(&mut rec);
+            let mut rec = update_cb[0].begin().expect("Begin UpdateCmdRec");
+            tfb_mut.sink_transfer_commands(&mut rec);
+            tfb_mut.sink_graphics_ready_commands(&mut rec);
         }
 
         let attdesc = br::AttachmentDescription::new(e.backbuffer_format(),
@@ -134,10 +211,10 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
         let descriptor_main = descriptor_pool.alloc(&[&descriptor_layout]).expect("Create main Descriptor");
         let mut dsub = DescriptorSetUpdateBatch::new();
         dsub.write(descriptor_main[0], 0, br::DescriptorUpdateInfo::UniformBuffer(vec![
-            (buffer.native_ptr(), 0 .. std::mem::size_of::<Uniform>())
+            (buffers.buffer.0.native_ptr(), buffers.range_in_mut_buffer(0 .. std::mem::size_of::<Uniform>()))
         ]));
         dsub.write(descriptor_main[0], 1, br::DescriptorUpdateInfo::CombinedImageSampler(vec![
-            (None, image.native_ptr(), br::ImageLayout::ShaderReadOnlyOpt)
+            (None, buffers.textures[0].native_ptr(), br::ImageLayout::ShaderReadOnlyOpt)
         ]));
         dsub.submit(&e.graphics());
 
@@ -167,15 +244,16 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
             cr.begin_render_pass(&renderpass, fb, fb.size().clone().into(), &[br::ClearValue::Color([0.0; 4])], true);
             gp.bind(&mut cr);
             cr.bind_graphics_descriptor_sets(0, &descriptor_main, &[]);
-            cr.bind_vertex_buffers(0, &[(&buffer, vertices_offset as _)]);
+            cr.bind_vertex_buffers(0, &[(&buffers.buffer.0, vertices_offset as _)]);
             cr.draw(4, 1, 0, 0);
             cr.end_render_pass();
         }
 
         Game {
-            buffer, render_cb, renderpass, framebuffers,
+            render_cb, renderpass, framebuffers,
             descriptor: (descriptor_layout, descriptor_pool, descriptor_main), gp_main: gp,
-            stg_buffer: stg_buffer2, rot: 0.0, update_cb, vertices_offset, _res: (image, smp),
+            rot: 0.0, vertices_offset, _sampler: smp,
+            buffers, update_cb, mut_uniform_offset,
             ph: PhantomData
         }
     }
@@ -183,13 +261,14 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
     fn update(&mut self, e: &peridot::Engine<Self, PL>, on_backbuffer_of: u32)
             -> (Option<br::SubmissionBatch>, br::SubmissionBatch) {
         self.rot += 1.0f32.to_radians();
-        self.stg_buffer.guard_map(size_of::<Matrix4F32>() as _, |m| unsafe {
-            *m.get_mut::<Matrix4F32>(size_of::<Matrix4F32>() * on_backbuffer_of as usize) =
-                Quaternion::new(self.rot, Vector3F32::up()).into();
+        self.buffers.mut_buffer.0.guard_map(size_of::<Matrix4F32>() as _, |m| unsafe
+        {
+            m.get_mut::<Uniform>(self.mut_uniform_offset as _).object
+                = Quaternion::new(self.rot, Vector3F32::up()).into();
         }).expect("Update DynamicStgBuffer");
 
         (Some(br::SubmissionBatch {
-            command_buffers: Cow::Borrowed(&self.update_cb[on_backbuffer_of as usize..on_backbuffer_of as usize + 1]),
+            command_buffers: Cow::Borrowed(&self.update_cb[..]),
             .. Default::default()
         }), br::SubmissionBatch {
             command_buffers: Cow::Borrowed(&self.render_cb[on_backbuffer_of as usize..on_backbuffer_of as usize + 1]),
@@ -215,7 +294,7 @@ impl<PL: peridot::NativeLinker> Game<PL> {
                 &[br::ClearValue::Color([0.0; 4])], true);
             self.gp_main.bind(&mut cr);
             cr.bind_graphics_descriptor_sets(0, &self.descriptor.2, &[]);
-            cr.bind_vertex_buffers(0, &[(&self.buffer, self.vertices_offset as _)]);
+            cr.bind_vertex_buffers(0, &[(&self.buffers.buffer.0, self.vertices_offset as _)]);
             cr.draw(4, 1, 0, 0);
             cr.end_render_pass();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@ mod asset; pub use self::asset::*;
 mod input; pub use self::input::*;
 mod model; pub use self::model::*;
 
-pub trait NativeLinker {
+pub trait NativeLinker
+{
     type AssetLoader: PlatformAssetLoader;
     type RenderTargetProvider: PlatformRenderTarget;
     type InputProcessor: InputProcessPlugin;
@@ -41,10 +42,11 @@ pub trait NativeLinker {
     fn rendering_precision(&self) -> f32 { 1.0 }
 }
 
-pub trait EngineEvents<PL: NativeLinker> : Sized {
+pub trait EngineEvents<PL: NativeLinker> : Sized
+{
     fn init(_e: &Engine<Self, PL>) -> Self;
     /// Updates the game and passes copying(optional) and rendering command batches to the engine.
-    fn update(&mut self, _e: &Engine<Self, PL>, _on_backbuffer_of: u32)
+    fn update(&mut self, _e: &Engine<Self, PL>, _on_backbuffer_of: u32, _delta_time: Duration)
             -> (Option<br::SubmissionBatch>, br::SubmissionBatch) {
         (None, br::SubmissionBatch::default())
     }
@@ -54,11 +56,13 @@ pub trait EngineEvents<PL: NativeLinker> : Sized {
     /// (called after discard_backbuffer_resources so re-create discarded resources here)
     fn on_resize(&mut self, _e: &Engine<Self, PL>, _new_size: math::Vector2<usize>) {}
 }
-impl<PL: NativeLinker> EngineEvents<PL> for () {
+impl<PL: NativeLinker> EngineEvents<PL> for ()
+{
     fn init(_e: &Engine<Self, PL>) -> Self { () }
 }
 
-pub struct Engine<E: EngineEvents<PL>, PL: NativeLinker> {
+pub struct Engine<E: EngineEvents<PL>, PL: NativeLinker>
+{
     nativelink: PL,
     surface: SurfaceInfo,
     wrt: Discardable<WindowRenderTargets>,
@@ -68,8 +72,10 @@ pub struct Engine<E: EngineEvents<PL>, PL: NativeLinker> {
     gametimer: GameTimer,
     last_rendering_completion: StateFence
 }
-impl<E: EngineEvents<PL>, PL: NativeLinker> Engine<E, PL> {
-    pub fn launch(name: &str, version: (u32, u32, u32), nativelink: PL) -> br::Result<Self> {
+impl<E: EngineEvents<PL>, PL: NativeLinker> Engine<E, PL>
+{
+    pub fn launch(name: &str, version: (u32, u32, u32), nativelink: PL) -> br::Result<Self>
+    {
         let g = Graphics::new(name, version, nativelink.render_target_provider().surface_extension_name())?;
         let surface = nativelink.render_target_provider().create_surface(&g.instance, &g.adapter,
             g.graphics_queue.family)?;
@@ -144,7 +150,7 @@ impl<E: EngineEvents<PL>, PL: NativeLinker> Engine<E, PL> {
 
         {
             let mut ulib = self.userlib_mut();
-            let (copy_submission, mut fb_submission) = ulib.update(self, bb_index);
+            let (copy_submission, mut fb_submission) = ulib.update(self, bb_index, dt);
             if let Some(mut cs) = copy_submission {
                 // copy -> render
                 cs.signal_semaphores.to_mut().push(&self.g.buffer_ready);

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -54,6 +54,7 @@ impl BufferContent {
 macro_rules! align2 {
     ($v: expr, $a: expr) => (($v + ($a - 1)) & !($a - 1))
 }
+#[derive(Clone)]
 pub struct BufferPrealloc<'g> { g: &'g Graphics, usage: br::BufferUsage, offsets: Vec<u64>, total: u64 }
 impl<'g> BufferPrealloc<'g> {
     pub fn new(g: &'g Graphics) -> Self {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -456,4 +456,14 @@ impl FixedMemory
             textures: textures.into_textures()
         })
     }
+
+    pub fn range_in_mut_buffer<T>(&self, r: Range<T>) -> Range<T> where
+        T: std::ops::Add<Output = T> + std::convert::TryFrom<u64> + Copy
+    {
+        match T::try_from(self.mut_buffer_placement)
+        {
+            Ok(p) => r.start + p .. r.end + p,
+            Err(_) => panic!("Overflowing Placement offset")
+        }
+    }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -40,7 +40,7 @@ impl SurfaceInfo
 
 pub(super) struct WindowRenderTargets
 {
-    chain: br::Swapchain, bb: Vec<br::ImageView>, command_completions_for_backbuffer: Vec<StateFence>
+    chain: br::Swapchain, bb: Vec<br::ImageView>
 }
 impl WindowRenderTargets
 {
@@ -62,14 +62,13 @@ impl WindowRenderTargets
         
         let isr_c0 = br::ImageSubresourceRange::color(0, 0);
         let images = chain.get_images()?;
-        let (mut bb, mut command_completions_for_backbuffer) =
-            (Vec::with_capacity(images.len()), Vec::with_capacity(images.len()));
-        for x in images {
+        let mut bb = Vec::with_capacity(images.len());
+        for x in images
+        {
             bb.push(x.create_view(None, None, &Default::default(), &isr_c0)?);
-            command_completions_for_backbuffer.push(StateFence::new(&g.device)?);
         }
 
-        return Ok(WindowRenderTargets { command_completions_for_backbuffer, bb, chain });
+        return Ok(WindowRenderTargets { bb, chain });
     }
 
     pub(super) fn emit_initialize_backbuffers_commands(&self, recorder: &mut br::CmdRecord) {
@@ -88,28 +87,6 @@ impl WindowRenderTargets
     }
     pub fn present_on(&self, q: &br::Queue, index: u32, occurence_after: &[&br::Semaphore]) -> br::Result<()> {
         self.chain.queue_present(q, index, occurence_after)
-    }
-    pub fn command_completion_for_backbuffer(&self, index: usize) -> &StateFence {
-        &self.command_completions_for_backbuffer[index]
-    }
-    pub fn command_completion_for_backbuffer_mut(&mut self, index: usize) -> &mut StateFence {
-        &mut self.command_completions_for_backbuffer[index]
-    }
-    pub fn wait_all_command_completion_for_backbuffer(&mut self) -> br::Result<()> {
-        {
-            let fences = self.command_completions_for_backbuffer.iter()
-                .filter(|x| x.is_signaled()).map(|x| x.object()).collect::<Vec<_>>();
-            if !fences.is_empty() { br::Fence::wait_multiple(&fences, true, None)?; }
-        }
-        for f in &mut self.command_completions_for_backbuffer { unsafe { f.unsignal(); } }
-        return Ok(());
-    }
-}
-impl Drop for WindowRenderTargets
-{
-    fn drop(&mut self)
-    {
-        for f in self.command_completions_for_backbuffer.iter_mut() { f.wait().expect("waiting completion fence"); }
     }
 }
 


### PR DESCRIPTION
Transferを直列で、Render/Updateを並列にする。この方式は旧interlude(hardgrad_extent)で実績がある。

### あとでやる

- [x] FixedBuffer/FixedBufferInitializerを分離してPRにする これ便利にできたと思うので