### PR TITLE
固定長バッファを使いやすく

### DIFF
--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,6 +1,6 @@
 use bedrock as br; use self::br::traits::*;
 use super::*;
-use std::ops::Deref;
+use std::ops::{Deref, Range};
 use std::mem::{size_of, transmute};
 use num::Integer;
 
@@ -54,6 +54,7 @@ impl BufferContent {
 macro_rules! align2 {
     ($v: expr, $a: expr) => (($v + ($a - 1)) & !($a - 1))
 }
+#[derive(Clone)]
 pub struct BufferPrealloc<'g> { g: &'g Graphics, usage: br::BufferUsage, offsets: Vec<u64>, total: u64 }
 impl<'g> BufferPrealloc<'g> {
     pub fn new(g: &'g Graphics) -> Self {
@@ -390,4 +391,68 @@ impl Deref for TextureInstantiatedGroup
 {
     type Target = [Texture2D];
     fn deref(&self) -> &[Texture2D] { &self.1 }
+}
+
+/// Describing the type that can be used as initializer of `FixedBuffer`s
+pub trait FixedBufferInitializer
+{
+    /// Setup memory data in staging buffer
+    fn stage_data(&mut self, m: &br::MappedMemoryRange);
+    fn buffer_graphics_ready(&self, tfb: &mut TransferBatch, buf: &Buffer, range: Range<u64>);
+}
+/// The Fix-sized buffers and textures manager
+pub struct FixedMemory
+{
+    /// Device accessible buffer object
+    pub buffer: (Buffer, u64),
+    /// Host buffer staging per-frame mutable data
+    pub mut_buffer: (Buffer, u64),
+    /// The placement offset of mut_buffer data in buffer
+    pub mut_buffer_placement: u64,
+    /// Textures
+    pub textures: Vec<Texture2D>
+}
+impl FixedMemory
+{
+    /// Initialize a FixedMemory using preallocation structures
+    pub fn new<'g, I: FixedBufferInitializer + ?Sized>(
+        g: &'g Graphics,
+        mut prealloc: BufferPrealloc<'g>,
+        prealloc_mut: BufferPrealloc<'g>,
+        textures: TextureInitializationGroup<'g>,
+        initializer: &mut I, tfb: &mut TransferBatch) -> br::Result<Self>
+    {
+        let mut_buffer = prealloc_mut.build_upload()?;
+        let mut p_bufferdata_prealloc = prealloc.clone();
+        let imm_buffer_size = p_bufferdata_prealloc.total_size();
+        let mut_buffer_placement = p_bufferdata_prealloc.merge(&prealloc_mut);
+        let buffer = p_bufferdata_prealloc.build_transferred()?;
+
+        let tex_preallocs = textures.prealloc(&mut prealloc)?;
+        let stg_buffer_fullsize = prealloc.total_size();
+        let stg_buffer = prealloc.build_upload()?;
+
+        let (mut mb, mut mb_mut) = (MemoryBadget::new(g), MemoryBadget::new(g));
+        mb.add(buffer);
+        mb_mut.add(mut_buffer);
+        let (textures, mut bufs) = tex_preallocs.alloc_and_instantiate(mb)?;
+        let buffer = bufs.pop().expect("objectless").unwrap_buffer();
+        let mut_buffer = mb_mut.alloc_upload()?.pop().expect("objectless").unwrap_buffer();
+        let mut mb_stg = MemoryBadget::new(g);
+        mb_stg.add(stg_buffer);
+        let stg_buffer = mb_stg.alloc_upload()?.pop().expect("objectless").unwrap_buffer();
+
+        stg_buffer.guard_map(stg_buffer_fullsize, |m| { textures.stage_data(m); initializer.stage_data(m); })?;
+
+        textures.copy_from_stage_batches(tfb, &stg_buffer);
+        tfb.add_mirroring_buffer(&stg_buffer, &buffer, 0, imm_buffer_size);
+        initializer.buffer_graphics_ready(tfb, &buffer, 0 .. imm_buffer_size);
+
+        Ok(FixedMemory
+        {
+            buffer: (buffer, imm_buffer_size), mut_buffer: (mut_buffer, prealloc_mut.total_size()),
+            mut_buffer_placement,
+            textures: textures.into_textures()
+        })
+    }
 }


### PR DESCRIPTION
#57 で言ってたやつ

固定長のバッファの確保から初期化までを `FixedMemory` が担当する。バッファの中身のステージングおよび欲しいメモリバリアの指定は `FixedBufferInitializer` を実装した型が担当する( `FixedMemory::new` で指定する)。