### PR TITLE
不要な依存を削れるように(pvp)

### DIFF
--- a/tools/shaderbuild/Cargo.toml
+++ b/tools/shaderbuild/Cargo.toml
@@ -7,6 +7,6 @@ authors = ["S.Percentage <Syn.Tri.Naga@gmail.com>"]
 clap = "2.31"
 bedrock = { git = "https://github.com/Pctg-x8/bedrock.git" }
 regex = "1.0"
-peridot-vertex-processing-pack = { path = "../../vertex-processing-pack" }
+peridot-vertex-processing-pack = { path = "../../vertex-processing-pack", default-features = false }
 log = "0.4"
 env_logger = "0.5"

--- a/vertex-processing-pack/Cargo.toml
+++ b/vertex-processing-pack/Cargo.toml
@@ -3,7 +3,11 @@ name = "peridot-vertex-processing-pack"
 version = "0.1.0"
 authors = ["S.Percentage <Syn.Tri.Naga@gmail.com>"]
 
+[features]
+default = ["with-loader-impl"]
+with-loader-impl = ["peridot"]
+
 [dependencies]
 bedrock = { git = "https://github.com/Pctg-x8/bedrock" }
-peridot = { path = ".." }
+peridot = { path = "..", optional = true }
 peridot-serialization-utils = { path = "../serialization-utils" }

--- a/vertex-processing-pack/src/lib.rs
+++ b/vertex-processing-pack/src/lib.rs
@@ -5,10 +5,13 @@ extern crate peridot_serialization_utils; use peridot_serialization_utils::*;
 
 use bedrock as br;
 use std::io::{
-    Read, Write, BufRead, BufReader, Seek, SeekFrom, Result as IOResult, Error as IOError, ErrorKind, Cursor
+    Write, BufRead, BufReader, Seek, SeekFrom, Result as IOResult, Error as IOError, ErrorKind, Cursor
 };
+#[cfg(feature = "with-loader-impl")]
+use std::io::Read;
 use std::fs::File;
 use std::path::Path;
+#[cfg(feature = "with-loader-impl")]
 use std::ffi::CString;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,6 +61,7 @@ impl peridot::FromAsset for PvpContainer
     }
 }
 
+#[cfg(feature = "with-loader-impl")]
 pub struct PvpShaderModules<'d>
 {
     bindings: Vec<br::vk::VkVertexInputBindingDescription>, attributes: Vec<br::vk::VkVertexInputAttributeDescription>,
@@ -65,6 +69,7 @@ pub struct PvpShaderModules<'d>
     vertex_spec_constants: Option<(Vec<br::vk::VkSpecializationMapEntry>, br::DynamicDataCell<'d>)>,
     fragment_spec_constants: Option<(Vec<br::vk::VkSpecializationMapEntry>, br::DynamicDataCell<'d>)>,
 }
+#[cfg(feature = "with-loader-impl")]
 impl<'d> PvpShaderModules<'d>
 {
     pub fn new(device: &br::Device, container: PvpContainer) -> br::Result<Self>

--- a/vertex-processing-pack/src/lib.rs
+++ b/vertex-processing-pack/src/lib.rs
@@ -46,7 +46,9 @@ impl PvpContainer {
     }
 }
 
+#[cfg(feature = "with-loader-impl")]
 impl peridot::LogicalAssetData for PvpContainer { const EXT: &'static str = "pvp"; }
+#[cfg(feature = "with-loader-impl")]
 impl peridot::FromAsset for PvpContainer
 {
     type Error = IOError;
@@ -55,6 +57,7 @@ impl peridot::FromAsset for PvpContainer
         PvpContainerReader::new(BufReader::new(asset)).and_then(PvpContainerReader::into_container)
     }
 }
+
 pub struct PvpShaderModules<'d>
 {
     bindings: Vec<br::vk::VkVertexInputBindingDescription>, attributes: Vec<br::vk::VkVertexInputAttributeDescription>,


### PR DESCRIPTION
vertex-processing-packにAssetLoaderの実装を移したらshaderbuildにいらない依存が入ったので、AssetLoaderをオプトアウトして依存を消せるようにした

デフォルトではAssetLoaderの実装がある(不要ならdefault-featuresをfalseにして切る)