### PR TITLE
Mac向けビルド周り修正

### DIFF
--- a/cradle/mac/Cargo.template.toml
+++ b/cradle/mac/Cargo.template.toml
@@ -5,6 +5,10 @@ authors = ["S.Percentage <Syn.Tri.Naga@gmail.com>"]
 edition = "2018"
 build = "build.rs"
 
+[lib]
+crate-type = ["staticlib"]
+name = "pegamelib"
+
 [features]
 UseExternalAssetPath = []
 

--- a/cradle/mac/peridot-cradle/peridot-cradle.xcodeproj/project.pbxproj
+++ b/cradle/mac/peridot-cradle/peridot-cradle.xcodeproj/project.pbxproj
@@ -556,7 +556,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../../../target/debug";
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../target/debug";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "";
@@ -583,7 +583,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../../../target/debug";
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../target/release";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "";

--- a/cradle/mac/peridot-cradle/peridot-cradle/Info.plist
+++ b/cradle/mac/peridot-cradle/peridot-cradle/Info.plist
@@ -20,13 +20,15 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2018 S.Percentage. All rights reserved.</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 </dict>
 </plist>


### PR DESCRIPTION
cradleをworkspaceから外したのでlibの出力フォルダが変わっていたのと、ライブラリ出力系の設定がmanifestになかったので追加