### PR TITLE
Bump to vulkansdk-macos 1.1.130.0

### DIFF
--- a/cradle/mac/peridot-cradle/peridot-cradle.xcodeproj/project.pbxproj
+++ b/cradle/mac/peridot-cradle/peridot-cradle.xcodeproj/project.pbxproj
@@ -7,22 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4B40D4A821DB5BB400C1B31F /* MoltenVK_icd.json in Copy Vulkan ICD Files */ = {isa = PBXBuildFile; fileRef = 4B40D4A721DB5B9E00C1B31F /* MoltenVK_icd.json */; };
-		4B40D4AA21DB5BF800C1B31F /* VkLayer_unique_objects.json in Copy Vulkan Layer Definition Files */ = {isa = PBXBuildFile; fileRef = 4B40D4A021DB5B9E00C1B31F /* VkLayer_unique_objects.json */; };
-		4B40D4AB21DB5BFA00C1B31F /* VkLayer_threading.json in Copy Vulkan Layer Definition Files */ = {isa = PBXBuildFile; fileRef = 4B40D4A121DB5B9E00C1B31F /* VkLayer_threading.json */; };
-		4B40D4AC21DB5BFC00C1B31F /* VkLayer_standard_validation.json in Copy Vulkan Layer Definition Files */ = {isa = PBXBuildFile; fileRef = 4B40D4A221DB5B9E00C1B31F /* VkLayer_standard_validation.json */; };
-		4B40D4AD21DB5BFF00C1B31F /* VkLayer_core_validation.json in Copy Vulkan Layer Definition Files */ = {isa = PBXBuildFile; fileRef = 4B40D4A321DB5B9E00C1B31F /* VkLayer_core_validation.json */; };
-		4B40D4AE21DB5C0200C1B31F /* VkLayer_parameter_validation.json in Copy Vulkan Layer Definition Files */ = {isa = PBXBuildFile; fileRef = 4B40D4A421DB5B9E00C1B31F /* VkLayer_parameter_validation.json */; };
-		4B40D4AF21DB5C0600C1B31F /* VkLayer_object_tracker.json in Copy Vulkan Layer Definition Files */ = {isa = PBXBuildFile; fileRef = 4B40D4A521DB5B9E00C1B31F /* VkLayer_object_tracker.json */; };
 		4B40D4B721DCFB5B00C1B31F /* assets.par in Resources */ = {isa = PBXBuildFile; fileRef = 4B40D4B621DCFB5B00C1B31F /* assets.par */; };
-		4B699CCB21DA435F0048FA7F /* vulkan.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4BC8ED2821B3F5FA00FB4AF9 /* vulkan.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4B699CCE21DA43D20048FA7F /* libvulkan.1.1.92.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4B699CCD21DA43D20048FA7F /* libvulkan.1.1.92.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4BA45A0621DB564500915AC9 /* libVkLayer_threading.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4BA45A0021DB564400915AC9 /* libVkLayer_threading.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4BA45A0721DB564500915AC9 /* libMoltenVK.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4BA45A0121DB564400915AC9 /* libMoltenVK.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4BA45A0821DB564500915AC9 /* libVkLayer_core_validation.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4BA45A0221DB564400915AC9 /* libVkLayer_core_validation.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4BA45A0921DB564500915AC9 /* libVkLayer_parameter_validation.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4BA45A0321DB564400915AC9 /* libVkLayer_parameter_validation.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4BA45A0A21DB564500915AC9 /* libVkLayer_object_tracker.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4BA45A0421DB564500915AC9 /* libVkLayer_object_tracker.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		4BA45A0B21DB564500915AC9 /* libVkLayer_unique_objects.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4BA45A0521DB564500915AC9 /* libVkLayer_unique_objects.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		4BAF7A1921B2554E0006BE24 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4BAF7A1821B2554E0006BE24 /* Assets.xcassets */; };
 		4BAF7A1C21B2554E0006BE24 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4BAF7A1A21B2554E0006BE24 /* MainMenu.xib */; };
 		4BAF7A2721B29F1F0006BE24 /* PeridotRenderableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAF7A2621B29F1F0006BE24 /* PeridotRenderableView.swift */; };
@@ -35,62 +20,24 @@
 		4BC8ED2321B3F51600FB4AF9 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BC8ED2221B3F51600FB4AF9 /* IOSurface.framework */; };
 		4BC8ED2521B3F54400FB4AF9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BC8ED2421B3F54400FB4AF9 /* Foundation.framework */; };
 		4BC8ED2721B3F54900FB4AF9 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BC8ED2621B3F54900FB4AF9 /* QuartzCore.framework */; };
-		4BC8ED2921B3F5FA00FB4AF9 /* vulkan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BC8ED2821B3F5FA00FB4AF9 /* vulkan.framework */; };
 		4BC8ED2E21B9FC0900FB4AF9 /* NativeInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC8ED2D21B9FC0900FB4AF9 /* NativeInterface.swift */; };
+		980100B623AF192B004DEEF8 /* vulkan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 980100B523AF192B004DEEF8 /* vulkan.framework */; };
+		980100BC23AF202B004DEEF8 /* libMoltenVK.dylib in Copy Vulkan Frameworks */ = {isa = PBXBuildFile; fileRef = 980100BB23AF202B004DEEF8 /* libMoltenVK.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		980100BE23AF2049004DEEF8 /* vulkan.framework in Copy Vulkan Frameworks */ = {isa = PBXBuildFile; fileRef = 980100BD23AF2049004DEEF8 /* vulkan.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		980100C323AF2605004DEEF8 /* MoltenVK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 980100C223AF2605004DEEF8 /* MoltenVK.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		4B40D49D21DB5B8000C1B31F /* Copy Vulkan ICD Files */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = vulkan/icd.d;
-			dstSubfolderSpec = 7;
-			files = (
-				4B40D4A821DB5BB400C1B31F /* MoltenVK_icd.json in Copy Vulkan ICD Files */,
-			);
-			name = "Copy Vulkan ICD Files";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4B40D4A921DB5BBB00C1B31F /* Copy Vulkan Layer Definition Files */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = vulkan/explicit_layer.d;
-			dstSubfolderSpec = 7;
-			files = (
-				4B40D4AA21DB5BF800C1B31F /* VkLayer_unique_objects.json in Copy Vulkan Layer Definition Files */,
-				4B40D4AB21DB5BFA00C1B31F /* VkLayer_threading.json in Copy Vulkan Layer Definition Files */,
-				4B40D4AC21DB5BFC00C1B31F /* VkLayer_standard_validation.json in Copy Vulkan Layer Definition Files */,
-				4B40D4AD21DB5BFF00C1B31F /* VkLayer_core_validation.json in Copy Vulkan Layer Definition Files */,
-				4B40D4AE21DB5C0200C1B31F /* VkLayer_parameter_validation.json in Copy Vulkan Layer Definition Files */,
-				4B40D4AF21DB5C0600C1B31F /* VkLayer_object_tracker.json in Copy Vulkan Layer Definition Files */,
-			);
-			name = "Copy Vulkan Layer Definition Files";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4B699CC921DA434E0048FA7F /* CopyFiles */ = {
+		4B40D49D21DB5B8000C1B31F /* Copy Vulkan Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				4BA45A0621DB564500915AC9 /* libVkLayer_threading.dylib in CopyFiles */,
-				4BA45A0721DB564500915AC9 /* libMoltenVK.dylib in CopyFiles */,
-				4BA45A0821DB564500915AC9 /* libVkLayer_core_validation.dylib in CopyFiles */,
-				4BA45A0921DB564500915AC9 /* libVkLayer_parameter_validation.dylib in CopyFiles */,
-				4BA45A0A21DB564500915AC9 /* libVkLayer_object_tracker.dylib in CopyFiles */,
-				4BA45A0B21DB564500915AC9 /* libVkLayer_unique_objects.dylib in CopyFiles */,
-				4B699CCB21DA435F0048FA7F /* vulkan.framework in CopyFiles */,
+				980100BE23AF2049004DEEF8 /* vulkan.framework in Copy Vulkan Frameworks */,
+				980100BC23AF202B004DEEF8 /* libMoltenVK.dylib in Copy Vulkan Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4B699CCC21DA43B50048FA7F /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 6;
-			files = (
-				4B699CCE21DA43D20048FA7F /* libvulkan.1.1.92.dylib in CopyFiles */,
-			);
+			name = "Copy Vulkan Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -164,6 +111,12 @@
 		4BF8B2E021D1C0C8007F80AB /* MoltenVK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MoltenVK.framework; path = "../../../../../vulkansdk-macos-1.1.92.1/MoltenVK/macOS/framework/MoltenVK.framework"; sourceTree = "<group>"; };
 		4BF8B2E321DA0686007F80AB /* libvulkan.1.1.92.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvulkan.1.1.92.dylib; path = "../../../../../vulkansdk-macos-1.1.92.1/macOS/lib/libvulkan.1.1.92.dylib"; sourceTree = "<group>"; };
 		4BF8B2E521DA06A4007F80AB /* libvulkan.1.1.92.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvulkan.1.1.92.dylib; path = "../../../../../vulkansdk-macos-1.1.92.1/macOS/lib/libvulkan.1.1.92.dylib"; sourceTree = "<group>"; };
+		980100B523AF192B004DEEF8 /* vulkan.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = vulkan.framework; path = "../../../../../vulkansdk-macos-1.1.130.0/macOS/Frameworks/vulkan.framework"; sourceTree = "<group>"; };
+		980100B923AF1D49004DEEF8 /* vulkan.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = vulkan.framework; path = "../../../../../vulkansdk-macos-1.1.130.0/macOS/Frameworks/vulkan.framework"; sourceTree = "<group>"; };
+		980100BB23AF202B004DEEF8 /* libMoltenVK.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libMoltenVK.dylib; path = "../../../../../vulkansdk-macos-1.1.130.0/macOS/lib/libMoltenVK.dylib"; sourceTree = "<group>"; };
+		980100BD23AF2049004DEEF8 /* vulkan.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = vulkan.framework; path = "../../../../../vulkansdk-macos-1.1.130.0/macOS/Frameworks/vulkan.framework"; sourceTree = "<group>"; };
+		980100C023AF252E004DEEF8 /* MoltenVK_icd.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = MoltenVK_icd.json; path = "../../../../../vulkansdk-macos-1.1.130.0/macOS/etc/vulkan/icd.d/MoltenVK_icd.json"; sourceTree = "<group>"; };
+		980100C223AF2605004DEEF8 /* MoltenVK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MoltenVK.framework; path = "../../../../../vulkansdk-macos-1.1.130.0/MoltenVK/macOS/framework/MoltenVK.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -171,12 +124,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4BC8ED2921B3F5FA00FB4AF9 /* vulkan.framework in Frameworks */,
+				980100C323AF2605004DEEF8 /* MoltenVK.framework in Frameworks */,
 				4BC8ED2721B3F54900FB4AF9 /* QuartzCore.framework in Frameworks */,
 				4BC8ED2521B3F54400FB4AF9 /* Foundation.framework in Frameworks */,
 				4BC8ED2321B3F51600FB4AF9 /* IOSurface.framework in Frameworks */,
 				4BC8ED2121B3F50B00FB4AF9 /* IOKit.framework in Frameworks */,
 				4BC8ED1F21B3F4EC00FB4AF9 /* Metal.framework in Frameworks */,
+				980100B623AF192B004DEEF8 /* vulkan.framework in Frameworks */,
 				4BC8ED1D21B3F4C900FB4AF9 /* libc++.tbd in Frameworks */,
 				4BAF7A3721B3C85B0006BE24 /* libpegamelib.a in Frameworks */,
 			);
@@ -219,6 +173,10 @@
 		4BAF7A0A21B2554B0006BE24 = {
 			isa = PBXGroup;
 			children = (
+				980100C023AF252E004DEEF8 /* MoltenVK_icd.json */,
+				980100BD23AF2049004DEEF8 /* vulkan.framework */,
+				980100BB23AF202B004DEEF8 /* libMoltenVK.dylib */,
+				980100B923AF1D49004DEEF8 /* vulkan.framework */,
 				4B40D4B621DCFB5B00C1B31F /* assets.par */,
 				4B40D49E21DB5B9E00C1B31F /* vulkan */,
 				4BA45A0121DB564400915AC9 /* libMoltenVK.dylib */,
@@ -293,6 +251,8 @@
 		4BAF7A3321B3C7380006BE24 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				980100C223AF2605004DEEF8 /* MoltenVK.framework */,
+				980100B523AF192B004DEEF8 /* vulkan.framework */,
 				4BF8B2E021D1C0C8007F80AB /* MoltenVK.framework */,
 				4BC8ED2821B3F5FA00FB4AF9 /* vulkan.framework */,
 				4BC8ED2621B3F54900FB4AF9 /* QuartzCore.framework */,
@@ -318,10 +278,7 @@
 				4BAF7A0F21B2554B0006BE24 /* Sources */,
 				4BAF7A1021B2554B0006BE24 /* Frameworks */,
 				4BAF7A1121B2554B0006BE24 /* Resources */,
-				4B699CC921DA434E0048FA7F /* CopyFiles */,
-				4B699CCC21DA43B50048FA7F /* CopyFiles */,
-				4B40D49D21DB5B8000C1B31F /* Copy Vulkan ICD Files */,
-				4B40D4A921DB5BBB00C1B31F /* Copy Vulkan Layer Definition Files */,
+				4B40D49D21DB5B8000C1B31F /* Copy Vulkan Frameworks */,
 				4B699CCF21DA43D80048FA7F /* ShellScript */,
 			);
 			buildRules = (
@@ -395,7 +352,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "#!/bin/bash\n# Type a script or drag a script file from your workspace to insert its path.\n\n$PROJECT_DIR/edit-package.sh\n";
+			shellScript = "#!/bin/bash\n# Type a script or drag a script file from your workspace to insert its path.\n\n# $PROJECT_DIR/edit-package.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -545,11 +502,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "peridot-cradle/peridot_cradle.entitlements";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(HOME)/vulkansdk-macos-1.1.92.1/macOS/Frameworks",
-					"$(HOME)/vulkansdk-macos-1.1.92.1/MoltenVK/macOS/framework",
+					"$(HOME)/vulkansdk-macos-1.1.130.0/macOS/Frameworks",
+					"$(HOME)/vulkansdk-macos-1.1.130.0/MoltenVK/macOS/framework",
 				);
 				INFOPLIST_FILE = "peridot-cradle/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -562,6 +520,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cterm2.peridot.cradle.peridot-cradle";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/$(PRODUCT)peridot-cradle/peridot-cradle-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 			};
@@ -572,11 +531,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "peridot-cradle/peridot_cradle.entitlements";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(HOME)/vulkansdk-macos-1.1.92.1/macOS/Frameworks",
-					"$(HOME)/vulkansdk-macos-1.1.92.1/MoltenVK/macOS/framework",
+					"$(HOME)/vulkansdk-macos-1.1.130.0/macOS/Frameworks",
+					"$(HOME)/vulkansdk-macos-1.1.130.0/MoltenVK/macOS/framework",
 				);
 				INFOPLIST_FILE = "peridot-cradle/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -589,6 +549,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cterm2.peridot.cradle.peridot-cradle";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/$(PRODUCT)peridot-cradle/peridot-cradle-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 			};

--- a/cradle/mac/peridot-cradle/peridot-cradle.xcodeproj/xcshareddata/xcschemes/peridot-cradle.xcscheme
+++ b/cradle/mac/peridot-cradle/peridot-cradle.xcodeproj/xcshareddata/xcschemes/peridot-cradle.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:peridot-cradle.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -50,9 +48,7 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      stopOnEveryThreadSanitizerIssue = "YES"
       debugServiceExtension = "internal"
-      enableGPUValidationMode = "2"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -66,13 +62,16 @@
       </BuildableProductRunnable>
       <EnvironmentVariables>
          <EnvironmentVariable
+            key = "VK_ICD_FILENAMES"
+            value = "$HOME/vulkansdk-macos-1.1.130.0/macOS/etc/vulkan/icd.d/MoltenVK_icd.json"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "RUST_BACKTRACE"
             value = "1"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
なんか思ってたより設定簡単やんけ！ってなった(vulkan.frameworkとMoltenVK.framework入れるだけ)
peridotはStatic FrameworkとしてMoltenVKを取り込む https://github.com/KhronosGroup/MoltenVK/blob/master/Docs/MoltenVK_Runtime_UserGuide.md#install

- [ ] あとは環境変数 `VK_SDK_PATH` をどうするかだな......