### PR TITLE
download-artifact後のbuildcacheのディレクトリ見てみる

### DIFF
--- a/.github/workflows/integrity-test.yml
+++ b/.github/workflows/integrity-test.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           name: "Peridot IntegrityCheck BuildCache"
           path: .buildcache
+      - name: peeking buildcache
+        run: |
+          ls -l .buildcache
+          ls -l .buildcache/target/debug/build/byteorder-*/
       - name: Building as Checking
         uses: ./.github/actions/checkbuild-subdir
         with:


### PR DESCRIPTION
chownが必要か、はたまた別の要因か