### PR TITLE
rm: buildcache sharing

### DIFF
--- a/.github/workflows/integrity-test.yml
+++ b/.github/workflows/integrity-test.yml
@@ -16,17 +16,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Building as Checking
         uses: ./.github/actions/checkbuild-baselayer
-      - name: Correct package permission for upload-artifact
-        if: success()
-        run: |
-          sudo chmod -R o+r .buildcache/registry/src/github.com-*/unicode-xid-*
-          sudo chmod -R o+r .buildcache/target
-      - name: Uploading Build Artifacts
-        uses: actions/upload-artifact@v1
-        if: success()
-        with:
-          name: "Peridot IntegrityCheck BuildCache"
-          path: .buildcache
+      # - name: Uploading Build Artifacts
+      #   uses: actions/upload-artifact@v1
+      #   if: success()
+      #   with:
+      #     name: "Peridot IntegrityCheck BuildCache"
+      #     path: .buildcache
       - name: Notify as Failure
         uses: ./.github/actions/integrity-check-slack-notifier
         if: failure()
@@ -51,14 +46,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Checking out
         uses: actions/checkout@v2
-      - name: Downloading last Build Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: "Peridot IntegrityCheck BuildCache"
-          path: .buildcache
-      - name: Resetting buildcache owner
-        run: |
-          sudo chown -hR root:root .buildcache
+      # - name: Downloading last Build Artifacts
+      #   uses: actions/download-artifact@v1
+      #   with:
+      #     name: "Peridot IntegrityCheck BuildCache"
+      #     path: .buildcache
       - name: Building as Checking
         uses: ./.github/actions/checkbuild-subdir
         with:
@@ -87,28 +79,21 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Checking out
         uses: actions/checkout@v2
-      - name: Downloading last Build Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: "Peridot IntegrityCheck BuildCache"
-          path: .buildcache
-      - name: Resetting buildcache owner
-        run: |
-          ls -l .buildcache
-          ls -l .buildcache/target/debug/build/crc32fast-*
-          sudo chown -hR root:root .buildcache
-          ls -l .buildcache
-          ls -l .buildcache/target/debug/build/crc32fast-*
+      # - name: Downloading last Build Artifacts
+      #   uses: actions/download-artifact@v1
+      #   with:
+      #     name: "Peridot IntegrityCheck BuildCache"
+      #     path: .buildcache
       - name: Building as Checking
         uses: ./.github/actions/checkbuild-subdir
         with:
           path: .
-      - name: Uploading Build Artifacts
-        uses: actions/upload-artifact@v1
-        if: success()
-        with:
-          name: "Peridot IntegrityCheck BuildCache"
-          path: .buildcache
+      # - name: Uploading Build Artifacts
+      #   uses: actions/upload-artifact@v1
+      #   if: success()
+      #   with:
+      #     name: "Peridot IntegrityCheck BuildCache"
+      #     path: .buildcache
       - name: Notify as Failure
         uses: ./.github/actions/integrity-check-slack-notifier
         if: failure()
@@ -133,14 +118,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Checking out
         uses: actions/checkout@v2
-      - name: Downloading last Build Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: "Peridot IntegrityCheck BuildCache"
-          path: .buildcache
-      - name: Resetting buildcache owner
-        run: |
-          sudo chown -hR root:root .buildcache
+      # - name: Downloading last Build Artifacts
+      #   uses: actions/download-artifact@v1
+      #   with:
+      #     name: "Peridot IntegrityCheck BuildCache"
+      #     path: .buildcache
       - name: Building as Checking
         uses: ./.github/actions/checkbuild-subdir
         with:


### PR DESCRIPTION
artifact化するとpermissionが消える問題
https://github.com/actions/upload-artifact/issues/38

upload-artifact@v2がリリースされるまで、buildcacheのジョブ間共有は一旦なしの方向で