### PR TITLE
root明示する

### DIFF
--- a/.github/actions/codeform-checker/executor.sh
+++ b/.github/actions/codeform-checker/executor.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -xe
 
-python $INPUT_SCRIPT.py
+python /$INPUT_SCRIPT.py


### PR DESCRIPTION
デフォルトが/github/workspaceとかになるので、絶対パスじゃないといかん