### PR TITLE
LayoutedPipeline::layoutの返り値をRcにする

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,7 +499,7 @@ impl LayoutedPipeline
         LayoutedPipeline(p, layout.clone())
     }
     pub fn pipeline(&self) -> &br::Pipeline { &self.0 }
-    pub fn layout(&self) -> &br::PipelineLayout { &self.1 }
+    pub fn layout(&self) -> &Rc<br::PipelineLayout> { &self.1 }
     pub fn bind(&self, rec: &mut br::CmdRecord) { rec.bind_graphics_pipeline_pair(&self.0, &self.1); }
 }
 


### PR DESCRIPTION
別にDeref coercion効くんだから(≒仮に内部実装がArcになってもユーザー側はほぼ変わらないんだから)隠す必要はないと思う