### PR TITLE
ドキュメントのリダイレクト先

### DIFF
--- a/.github/actions/deployment-dev/firebase.json
+++ b/.github/actions/deployment-dev/firebase.json
@@ -5,6 +5,13 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "redirects": [
+      {
+        "source": "/",
+        "destination": "/dev/peridot/",
+        "type": 301
+      }
     ]
   }
 }


### PR DESCRIPTION
ルートへのアクセスを/dev/peridot/に落とす

https://firebase.google.com/docs/hosting/full-config?hl=ja#redirects