### PR TITLE
サイズが変わってない場合はそもそもresizeする必要はない

### DIFF
--- a/cradle/windows/Cargo.template.toml
+++ b/cradle/windows/Cargo.template.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 UseExternalAssetPath = []
 
 [dependencies]
-bedrock = { git = "https://github.com/Pctg-x8/bedrock", branch = "peridot" }
+bedrock = { git = "https://github.com/Pctg-x8/bedrock", branch = "peridot", features = ["Presentation", "Implements", "VK_KHR_win32_surface"] }
 peridot = { path = "../.." }
 log = "0.4"
 env_logger = "0.5"

--- a/cradle/windows/build.ps1
+++ b/cradle/windows/build.ps1
@@ -75,7 +75,7 @@ $ExternCrateName = $PackageName.Replace("-", "_")
 pub use $ExternCrateName::$EntryTyName as Game;" | Out-File $ScriptPath\src\userlib.rs -Encoding UTF8
 
 $CargoSubcommand = if ($Run) { "run" } else { "build" }
-$Features = @("bedrock/VK_KHR_win32_surface")
+$Features = @()
 $OptFlags = if ($Release) { "--release" } else { "" }
 if ($AssetDirectory) {
     $Env:PERIDOT_EXTERNAL_ASSET_PATH = $(Resolve-Path $AssetDirectory).Path


### PR DESCRIPTION
ないというか、Windowsではここ適当にしてたせいで初回にリサイズ処理が走るので、それをEngineEvents側でハンドルしてないといけなくてちょっとつらかった