### PR TITLE
crate名をkebab-caseに統一する

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "peridot_derive"
+name = "peridot-derive"
 version = "0.1.0"
 authors = ["S.Percentage <Syn.Tri.Naga@gmail.com>"]
 edition = "2018"

--- a/examples/vg/Cargo.toml
+++ b/examples/vg/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 peridot = { path = "../.." }
-peridot_derive = { path = "../../derive" }
+peridot-derive = { path = "../../derive" }
 bedrock = { git = "https://github.com/Pctg-x8/bedrock", branch = "peridot", features = ["VK_EXT_debug_report"] }
 log = "0.4"
 


### PR DESCRIPTION
今後もkebab-caseでやっていく
deriveだけなぜかsnake_caseだったので修正