### PR TITLE
BufferのMapを範囲指定できるようにする

### DIFF
--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -98,7 +98,7 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL>
             depth_range: 1.0 .. 10.0
         };
         cam.look_at(Vector3(0.0, 0.0, 0.0));
-        buffers.mut_buffer.0.guard_map(buffers.mut_buffer.1, |m| unsafe
+        buffers.mut_buffer.0.guard_map(0 .. buffers.mut_buffer.1, |m| unsafe
         {
             let (v, p) = cam.matrixes();
             let aspect = Matrix4::scale(Vector4(screen_aspect, 1.0, 1.0, 1.0));
@@ -226,7 +226,7 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL>
     {
         let dtsec = delta_time.as_secs() as f32 + delta_time.subsec_micros() as f32 / 1000_0000.0;
         self.rot += dtsec * 15.0;
-        self.buffers.mut_buffer.0.guard_map(self.mut_uniform_offset + size_of::<Uniform>() as u64, |m| unsafe
+        self.buffers.mut_buffer.0.guard_map(0 .. self.mut_uniform_offset + size_of::<Uniform>() as u64, |m| unsafe
         {
             m.get_mut::<Uniform>(self.mut_uniform_offset as _).object
                 = Quaternion::new(self.rot, Vector3F32::up()).into();

--- a/examples/vg/src/lib.rs
+++ b/examples/vg/src/lib.rs
@@ -119,7 +119,7 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL>
         let buffer = mb.alloc().expect("Mem Allocation").pop().expect("no objects?").unwrap_buffer();
         let stg_buffer = mb_stg.alloc_upload().expect("StgMem Allocation").pop().expect("no objects?").unwrap_buffer();
         
-        let (vg_renderer_params, vg_renderer_params2) = stg_buffer.guard_map(bp.total_size(), |m|
+        let (vg_renderer_params, vg_renderer_params2) = stg_buffer.guard_map(0 .. bp.total_size(), |m|
         {
             let p0 = ctx.stage_data_into(m, vg_offs);
             let p1 = ctx2.stage_data_into(m, vg_offs2);


### PR DESCRIPTION
全部mapするとたしかに場合によってはホスト側の仮想メモリバカ食いするよなと思ったので、範囲指定できるように修正