### PR TITLE
Fix dev package artifact name

### DIFF
--- a/.github/workflows/sdk-build.yml
+++ b/.github/workflows/sdk-build.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Build tools (For PowerShell Env)
         if: matrix.os == 'windows-latest'
         run: powershell.exe -File ./tools/build-all.ps1
+      - name: Update Bash (Only for MacOS)
+        if: matrix.os == 'macos-latest'
+        run: brew update bash
       - name: Build tools (For Bash Env)
         if: matrix.os != 'windows-latest'
         run: ./tools/build-all.sh

--- a/.github/workflows/sdk-build.yml
+++ b/.github/workflows/sdk-build.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Upload package to Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: "Peridot SDK: ${{ matrix.os }}"
+          name: "PeridotSDK-${{ matrix.os }}"
           path: peridot-sdk


### PR DESCRIPTION
アーティファクト名に:使えないのと、macOSのbashのバージョンが古い問題の対応