### PR TITLE
DescriptorSetLayoutのキャッシュ機構

### DIFF
--- a/src/layout_cache.rs
+++ b/src/layout_cache.rs
@@ -2,7 +2,6 @@
 
 use bedrock as br;
 use std::collections::HashMap;
-use std::rc::Rc;
 
 /// An object cache for DescriptorSetLayout
 pub struct DescriptorSetLayoutCache<'d> {

--- a/src/layout_cache.rs
+++ b/src/layout_cache.rs
@@ -2,6 +2,7 @@
 
 use bedrock as br;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 /// An object cache for DescriptorSetLayout
 pub struct DescriptorSetLayoutCache<'d> {
@@ -15,7 +16,7 @@ impl<'d> DescriptorSetLayoutCache<'d> {
         }
     }
 
-    /// Gets an object. And create a new object if not exists.
+    /// Get an object. And create a new object if not exists.
     pub fn query(
         &mut self,
         device: &br::Device,

--- a/src/layout_cache.rs
+++ b/src/layout_cache.rs
@@ -16,7 +16,11 @@ impl<'d> DescriptorSetLayoutCache<'d> {
     }
 
     /// Gets an object. And create a new object if not exists.
-    pub fn query(&mut self, device: &br::Device, bindings: &'d [br::DescriptorSetLayoutBinding<'d>]) -> &br::DescriptorSetLayout {
+    pub fn query(
+        &mut self,
+        device: &br::Device,
+        bindings: &'d [br::DescriptorSetLayoutBinding<'d>]
+    ) -> &br::DescriptorSetLayout {
         self.object_map.entry(bindings).or_insert_with(||
             br::DescriptorSetLayout::new(device, bindings).expect("Failed to create DescriptorSetLayout")
         )

--- a/src/layout_cache.rs
+++ b/src/layout_cache.rs
@@ -1,0 +1,24 @@
+//! Layout Cache
+
+use bedrock as br;
+use std::collections::HashMap;
+
+/// An object cache for DescriptorSetLayout
+pub struct DescriptorSetLayoutCache<'d> {
+    object_map: HashMap<&'d [br::DescriptorSetLayoutBinding<'d>], br::DescriptorSetLayout>
+}
+impl<'d> DescriptorSetLayoutCache<'d> {
+    /// Create an empty object cache
+    pub fn new() -> Self {
+        DescriptorSetLayoutCache {
+            object_map: HashMap::new()
+        }
+    }
+
+    /// Gets an object. And create a new object if not exists.
+    pub fn query(&mut self, device: &br::Device, bindings: &'d [br::DescriptorSetLayoutBinding<'d>]) -> &br::DescriptorSetLayout {
+        self.object_map.entry(bindings).or_insert_with(||
+            br::DescriptorSetLayout::new(device, bindings).expect("Failed to create DescriptorSetLayout")
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod utils; pub use self::utils::*;
 mod asset; pub use self::asset::*;
 mod input; pub use self::input::*;
 mod model; pub use self::model::*;
+mod layout_cache; pub use self::layout_cache::*;
 
 pub trait NativeLinker
 {


### PR DESCRIPTION
同じDescriptorSetLayoutがあったらそれを引っ張り出す。 PipelineLayoutは一旦考えない

ライフタイム制約がちょっとアレかもしれない
BaseEngineに入れるか別Moduleにするかは未定(でもまあMemoryBudgetとか入ってるし入れても良さそう)