### PR TITLE
TTFファイルローダ

### DIFF
--- a/builtin-assets/vg/sdf/shaders/curve_triangles.csh
+++ b/builtin-assets/vg/sdf/shaders/curve_triangles.csh
@@ -4,7 +4,7 @@ VertexInput {
 SpecConstant[VertexShader](0) TargetTextureWidth: float = 640.0;
 SpecConstant[VertexShader](1) TargetTextureHeight: float = 480.0;
 VertexShader {
-    RasterPosition = vec4((ipos / vec2(TargetTextureWidth, -TargetTextureHeight)) - 1.0, 0.0, 1.0);
+    RasterPosition = vec4((ipos / vec2(TargetTextureWidth, -TargetTextureHeight)) * 2.0 - 1.0, 0.0, 1.0);
     uv_out = uv;
 }
 Varyings VertexShader -> FragmentShader { uv_out: vec2; }

--- a/builtin-assets/vg/sdf/shaders/outline_distance.csh
+++ b/builtin-assets/vg/sdf/shaders/outline_distance.csh
@@ -5,7 +5,7 @@ SpecConstant[VertexShader](0) TargetTextureWidth: float = 640.0;
 SpecConstant[VertexShader](1) TargetTextureHeight: float = 480.0;
 SpecConstant[VertexShader](2) LineWidth: float = 1.0;
 VertexShader {
-    RasterPosition = vec4((ipos / vec2(TargetTextureWidth, -TargetTextureHeight)) - 1.0, 0.0, 1.0);
+    RasterPosition = vec4((ipos / vec2(TargetTextureWidth, -TargetTextureHeight)) * 2.0 - 1.0, 0.0, 1.0);
     pcoord = uv;
     limits = lim;
     scale = sc.x / LineWidth;

--- a/builtin-assets/vg/sdf/shaders/triangle_fans.csh
+++ b/builtin-assets/vg/sdf/shaders/triangle_fans.csh
@@ -4,7 +4,7 @@ VertexInput {
 SpecConstant[VertexShader](0) TargetTextureWidth: float = 0.5;
 SpecConstant[VertexShader](1) TargetTextureHeight: float = 0.5;
 VertexShader {
-    RasterPosition = vec4((ipos / vec2(TargetTextureWidth, -TargetTextureHeight)) - 1.0, 0.0, 1.0);
+    RasterPosition = vec4((ipos / vec2(TargetTextureWidth, -TargetTextureHeight)) * 2.0 - 1.0, 0.0, 1.0);
 }
 SpecConstant[FragmentShader](0) EnableColorOutput: bool = false;
 FragmentShader {

--- a/vg/src/font.rs
+++ b/vg/src/font.rs
@@ -225,7 +225,7 @@ impl FontProvider {
         &self, e: &peridot::Engine<NL>, asset_path: &str, size: f32
     ) -> Result<Font, FontConstructionError> {
         let a: TTFBlob = e.load(asset_path)?;
-        let conv = ATFRegisterScope::register(&self.factory, comdrive::ComPtr(AssetToFontConverter::new(&a)))?;
+        let conv = ATFRegisterScope::register(&self.factory, comdrive::ComPtr(AssetToFontConverter::new(a)))?;
         let fntfile = self.factory.new_custom_font_file_reference(&1u32, conv.object())?;
         let (is_supported, _, face_type, _) = fntfile.analyze()?;
         if !is_supported {

--- a/vg/src/font.rs
+++ b/vg/src/font.rs
@@ -132,6 +132,7 @@ impl FontProvider
 #[cfg(all(target_os = "macos", not(feature = "use-freetype")))]
 impl Font {
     pub fn set_em_size(&mut self, size: f32) { self.1 = size; }
+    pub fn size(&self) -> f32 { self.1 }
     pub fn scale_value(&self) -> f32 { self.1 / FontProvider::CTFONT_DEFAULT_SIZE }
     pub fn ascent(&self) -> f32 { self.0.ascent() as f32 * self.scale_value() }
 
@@ -240,6 +241,7 @@ impl FontProvider {
 #[cfg(all(target_os = "windows", not(feature = "use-freetype")))]
 impl Font {
     pub fn set_em_size(&mut self, size: f32) { self.1 = size; }
+    pub fn size(&self) -> f32 { self.1 }
     pub fn scale_value(&self) -> f32 { (96.0 * self.1 / 72.0) / self.units_per_em() as f32 }
     /// Returns a scaled ascent metric value
     pub fn ascent(&self) -> f32 { self.0.metrics().ascent as f32 }
@@ -324,6 +326,7 @@ impl FontProvider
 impl Font
 {
     pub fn set_em_size(&mut self, size: f32) { self.1 = size; self.0.set_size(size); }
+    pub fn size(&self) -> f32 { self.1 }
     pub fn scale_value(&self) -> f32 { self.1 / self.units_per_em() as f32 }
     pub fn ascent(&self) -> f32 { self.0.ascender() as _ }
 

--- a/vg/src/font.rs
+++ b/vg/src/font.rs
@@ -1,5 +1,4 @@
 
-use comdrive::AsRawHandle;
 use euclid::Rect;
 use peridot::math::Vector2;
 use lyon_path::builder::PathBuilder;
@@ -7,6 +6,7 @@ use lyon_path::builder::PathBuilder;
 #[cfg(all(target_os = "macos", not(feature = "use-freetype")))] use appkit::ObjcObjectBase;
 #[cfg(all(target_os = "windows", not(feature = "use-freetype")))] mod dwrite_driver;
 #[cfg(all(target_os = "windows", not(feature = "use-freetype")))] use self::dwrite_driver::*;
+#[cfg(all(target_os = "windows", not(feature = "use-freetype")))] use comdrive::AsRawHandle;
 #[cfg(feature = "use-freetype")] mod ft_drivers;
 #[cfg(feature = "use-fontconfig")] mod fc_drivers;
 

--- a/vg/src/font.rs
+++ b/vg/src/font.rs
@@ -225,7 +225,8 @@ impl FontProvider {
         &self, e: &peridot::Engine<NL>, asset_path: &str, size: f32
     ) -> Result<Font, FontConstructionError> {
         let a: TTFBlob = e.load(asset_path)?;
-        let fntfile = self.factory.new_custom_font_file_reference(&(), &dwrite_driver::AssetToFontConverter::new(&a))?;
+        let conv = ATFRegisterScope::register(&self.factory, comdrive::ComPtr(AssetToFontConverter::new(&a)))?;
+        let fntfile = self.factory.new_custom_font_file_reference(&1u32, conv.object())?;
         let (is_supported, _, face_type, _) = fntfile.analyze()?;
         if !is_supported {
             return Err(FontConstructionError::UnsupportedFontFile);

--- a/vg/src/font/dwrite_driver.rs
+++ b/vg/src/font/dwrite_driver.rs
@@ -121,7 +121,9 @@ unsafe impl comdrive::AsRawHandle<ID2D1SimplifiedGeometrySink> for PathEventRece
 
 pub struct ATFRegisterScope<'a>(&'a comdrive::dwrite::Factory, comdrive::ComPtr<AssetToFontConverter<'a>>);
 impl<'a> ATFRegisterScope<'a> {
-    pub fn register(factory: &'a comdrive::dwrite::Factory, atf: comdrive::ComPtr<AssetToFontConverter<'a>>) -> std::io::Result<Self> {
+    pub fn register(
+        factory: &'a comdrive::dwrite::Factory, atf: comdrive::ComPtr<AssetToFontConverter<'a>>
+    ) -> std::io::Result<Self> {
         factory.register_font_file_loader(unsafe { &*atf.0 }).map(|_| Self(factory, atf))
     }
 
@@ -138,16 +140,16 @@ pub struct AssetToFontConverter<'a> {
     base: ComBase<IDWriteFontFileLoaderVtbl>,
     asset: &'a super::TTFBlob
 }
-pub static ATF_VTABLE: IDWriteFontFileLoaderVtbl = IDWriteFontFileLoaderVtbl {
-    CreateStreamFromKey: AssetToFontConverter::create_stream_from_key,
-    parent: IUnknownVtbl {
-        QueryInterface: AssetToFontConverter::query_interface,
-        AddRef: ComBase::<IDWriteFontFileLoaderVtbl>::add_ref,
-        Release: ComBase::<IDWriteFontFileLoaderVtbl>::release
-    }
-};
 impl<'a> AssetToFontConverter<'a> {
-    pub unsafe extern "system" fn query_interface(this: *mut IUnknown, iid: REFIID, objret: *mut *mut c_void) -> HRESULT {
+    const VTABLE: &'static IDWriteFontFileLoaderVtbl = &IDWriteFontFileLoaderVtbl {
+        CreateStreamFromKey: AssetToFontConverter::create_stream_from_key,
+        parent: IUnknownVtbl {
+            QueryInterface: AssetToFontConverter::query_interface,
+            AddRef: ComBase::<IDWriteFontFileLoaderVtbl>::add_ref,
+            Release: ComBase::<IDWriteFontFileLoaderVtbl>::release
+        }
+    };
+    unsafe extern "system" fn query_interface(this: *mut IUnknown, iid: REFIID, objret: *mut *mut c_void) -> HRESULT {
         *objret = null_mut();
         if iid == &IDWriteFontFileLoader::uuidof() || iid == &IUnknown::uuidof() {
             *objret = this as *mut _;
@@ -158,9 +160,8 @@ impl<'a> AssetToFontConverter<'a> {
     }
 
     pub fn new(asset: &'a super::TTFBlob) -> *mut Self {
-        println!("vtbl: {:p}", &ATF_VTABLE);
         Box::into_raw(Box::new(Self {
-            base: ComBase::new(&ATF_VTABLE),
+            base: ComBase::new(Self::VTABLE),
             asset
         }))
     }

--- a/vg/src/font/dwrite_driver.rs
+++ b/vg/src/font/dwrite_driver.rs
@@ -1,7 +1,7 @@
 
 use libc::c_void;
 use winapi::Interface;
-use winapi::shared::minwindef::{ULONG};
+use winapi::shared::minwindef::ULONG;
 use winapi::shared::winerror::{S_OK, E_NOINTERFACE, HRESULT};
 use winapi::shared::guiddef::REFIID;
 use winapi::um::unknwnbase::{IUnknown, IUnknownVtbl};
@@ -9,6 +9,10 @@ use winapi::um::d2d1::{
     ID2D1SimplifiedGeometrySink, ID2D1SimplifiedGeometrySinkVtbl, D2D1_FIGURE_BEGIN, D2D1_FIGURE_END,
     D2D1_FILL_MODE, D2D1_PATH_SEGMENT,
     D2D1_FIGURE_END_CLOSED
+};
+use winapi::um::dwrite::{
+    IDWriteFontFileLoader, IDWriteFontFileLoaderVtbl,
+    IDWriteFontFileStream, IDWriteFontFileStreamVtbl
 };
 use std::ptr::null_mut;
 use lyon_path::PathEvent;
@@ -113,4 +117,114 @@ impl PathEventReceiver
 unsafe impl comdrive::AsRawHandle<ID2D1SimplifiedGeometrySink> for PathEventReceiver
 {
     fn as_raw_handle(&self) -> *mut ID2D1SimplifiedGeometrySink { self as *const _ as _ }
+}
+
+pub struct AssetToFontConverter<'a> {
+    base: ComBase<IDWriteFontFileLoaderVtbl>,
+    asset: &'a super::TTFBlob
+}
+impl<'a> AssetToFontConverter<'a> {
+    const VTABLE: &'static IDWriteFontFileLoaderVtbl = &IDWriteFontFileLoaderVtbl {
+        CreateStreamFromKey: Self::create_stream_from_key,
+        parent: IUnknownVtbl {
+            QueryInterface: Self::query_interface,
+            AddRef: ComBase::<IDWriteFontFileLoaderVtbl>::add_ref,
+            Release: ComBase::<IDWriteFontFileLoaderVtbl>::release
+        }
+    };
+    unsafe extern "system" fn query_interface(this: *mut IUnknown, iid: REFIID, objret: *mut *mut c_void) -> HRESULT
+    {
+        *objret = null_mut();
+        if iid == &IDWriteFontFileLoader::uuidof() || iid == &IUnknown::uuidof() {
+            *objret = this as *mut _;
+            return S_OK;
+        }
+        
+        E_NOINTERFACE
+    }
+
+    pub fn new(asset: &'a super::TTFBlob) -> Self {
+        Self {
+            base: ComBase::new(Self::VTABLE),
+            asset
+        }
+    }
+}
+/// IDWritFontFileLoader
+impl AssetToFontConverter<'_> {
+    unsafe extern "system" fn create_stream_from_key(
+        this: *mut IDWriteFontFileLoader,
+        _refkey: *const c_void,
+        _keysize: u32,
+        stream: *mut *mut IDWriteFontFileStream
+    ) -> HRESULT {
+        *stream = AssetStreamBridge::new((*(this as *mut Self)).asset) as *mut _;
+
+        S_OK
+    }
+}
+unsafe impl comdrive::AsRawHandle<IDWriteFontFileLoader> for AssetToFontConverter<'_> {
+    fn as_raw_handle(&self) -> *mut IDWriteFontFileLoader { self as *const Self as _ }
+}
+
+pub struct AssetStreamBridge<'a> {
+    base: ComBase<IDWriteFontFileStreamVtbl>,
+    asset: &'a super::TTFBlob
+}
+impl<'a> AssetStreamBridge<'a> {
+    const VTABLE: &'static IDWriteFontFileStreamVtbl = &IDWriteFontFileStreamVtbl {
+        GetFileSize: Self::get_size,
+        GetLastWriteTime: Self::get_last_write_time,
+        ReadFileFragment: Self::read_file_fragment,
+        ReleaseFileFragment: Self::release_file_fragment,
+        parent: IUnknownVtbl {
+            QueryInterface: Self::query_interface,
+            AddRef: ComBase::<IDWriteFontFileStreamVtbl>::add_ref,
+            Release: ComBase::<IDWriteFontFileStreamVtbl>::release
+        }
+    };
+    unsafe extern "system" fn query_interface(this: *mut IUnknown, iid: REFIID, objret: *mut *mut c_void) -> HRESULT {
+        *objret = null_mut();
+        if iid == &IDWriteFontFileStream::uuidof() || iid == &IUnknown::uuidof() {
+            *objret = this as *mut _;
+            return S_OK;
+        }
+
+        E_NOINTERFACE
+    }
+
+    fn new(asset: &'a super::TTFBlob) -> *mut Self {
+        Box::into_raw(Box::new(Self {
+            base: ComBase::new(Self::VTABLE),
+            asset
+        }))
+    }
+}
+/// IDWriteFontFileStream
+impl AssetStreamBridge<'_> {
+    unsafe extern "system" fn get_size(this: *mut IDWriteFontFileStream, size: *mut u64) -> HRESULT {
+        *size = (*(this as *mut Self)).asset.0.len() as _;
+        S_OK
+    }
+    unsafe extern "system" fn get_last_write_time(
+        _this: *mut IDWriteFontFileStream, last_write_time: *mut u64
+    ) -> HRESULT {
+        *last_write_time = 0;
+        S_OK
+    }
+    unsafe extern "system" fn read_file_fragment(
+        this: *mut IDWriteFontFileStream,
+        fragment_start: *mut *const c_void,
+        file_offset: u64,
+        _fragment_size: u64,
+        fragment_context: *mut *mut c_void
+    ) -> HRESULT {
+        *fragment_context = null_mut();
+        *fragment_start = (*(this as *mut Self)).asset.0.as_ptr().add(file_offset as _) as *const _;
+
+        S_OK
+    }
+    unsafe extern "system" fn release_file_fragment(
+        _this: *mut IDWriteFontFileStream, _fragment_context: *mut c_void
+    ) {}
 }


### PR DESCRIPTION
カスタムのTTFファイルを使えるようにする(よくよく考えたら普通のゲームでシステムフォント使うってあんまないな)

- [x] DirectWrite(Windows)
- [x] CoreFont(macOS)
  - 実装のみ 未検証
- [x] freetype2