### PR TITLE
PulseAudioで初期化タイミングで死ぬやつを直す

### DIFF
--- a/cradle/linux/src/main.rs
+++ b/cradle/linux/src/main.rs
@@ -223,7 +223,7 @@ impl GameDriver {
         let usercode = userlib::Game::init(&mut engine);
         engine.input_mut().set_nativelink(Box::new(input::InputNativeLink::new(x11)));
         engine.postinit();
-        let _snd = async_std::task::block_on(NativeAudioEngine::new(engine.audio_mixer()));
+        let _snd = NativeAudioEngine::new(engine.audio_mixer());
 
         GameDriver { engine, usercode, _snd }
     }

--- a/cradle/linux/src/main.rs
+++ b/cradle/linux/src/main.rs
@@ -248,6 +248,7 @@ fn main() {
     let mut input = input::InputSystem::new(&ep, 1, 2);
 
     x11.borrow().show();
+    gd.engine.audio_mixer().write().expect("Failed to mutate audio mixer").start();
     let mut events = vec![unsafe { std::mem::MaybeUninit::zeroed().assume_init() }; 2 + input.managed_devices_count()];
     'app: loop {
         if events.len() != 2 + input.managed_devices_count() {

--- a/cradle/linux/src/sound_backend/pa.rs
+++ b/cradle/linux/src/sound_backend/pa.rs
@@ -3,62 +3,120 @@
 use pulseaudio_rs as pa;
 use std::sync::{Arc, RwLock};
 use std::pin::Pin;
+use std::cell::RefCell;
 
-struct AudioDataWriter(Arc<RwLock<peridot::audio::Mixer>>);
+trait IAudioBitstreamConverter {
+	fn sample_count(&self, bytes: usize) -> usize;
+	fn convert(&self, floats: &[f32], into: &mut [u8]);
+}
+pub struct SignedInt24LE;
+impl IAudioBitstreamConverter for SignedInt24LE {
+	fn sample_count(&self, bytes: usize) -> usize { bytes / 3 }
+	fn convert(&self, floats: &[f32], into: &mut [u8]) {
+		for (n, &e) in floats.into_iter().enumerate() {
+			let v = unsafe { std::mem::transmute::<_, u32>((e * 8388607.0) as i32) };
+			into[n * 3 + 0] = (v & 0xff) as _;
+			into[n * 3 + 1] = ((v >> 8) & 0xff) as _;
+			into[n * 3 + 2] = ((v >> 16) & 0xff) as _;
+		}
+	}
+}
+impl IAudioBitstreamConverter for f32 {
+	fn sample_count(&self, bytes: usize) -> usize { bytes >> 2 }
+	fn convert(&self, floats: &[f32], into: &mut [u8]) {
+		into.copy_from_slice(unsafe { std::slice::from_raw_parts(floats.as_ptr() as _, floats.len() << 2) });
+	}
+}
+
+struct AudioDataWriter {
+	mixer: Arc<RwLock<peridot::audio::Mixer>>,
+	conv: RefCell<Box<dyn IAudioBitstreamConverter>>
+}
 impl pa::stream::WriteRequestHandler for AudioDataWriter
 {
-	fn callback(&mut self, stream: &mut pa::StreamRef, nbytes: usize)
+	fn callback(&self, stream: &mut pa::StreamRef, nbytes: usize)
 	{
 		let mut rem = nbytes;
 		while rem > 0
 		{
 			let (bufptr, len) = stream.begin_write(rem).expect("BeginWrite failed!");
-			let buf = unsafe { std::slice::from_raw_parts_mut(bufptr as *mut f32, len >> 2) };
-			for b in buf.iter_mut() { *b = 0.0; }
-			self.0.write().expect("Mixer Write Failed!").process(buf);
-			stream.write_slice(&buf, None).expect("Writing Slice failed!");
+			let aslice = unsafe { std::slice::from_raw_parts_mut(bufptr as *mut u8, len) };
+			let mut buf = vec![0.0f32; self.conv.borrow().sample_count(len)];
+			self.mixer.write().expect("Mixer Write Failed!").process(&mut buf);
+			self.conv.borrow().convert(&buf, aslice);
+			stream.write_slice(&aslice, None).expect("Writing Slice failed!");
 			rem -= len;
 		}
 	}
 }
 
-pub struct NativeAudioEngine
-{
-	mlp: pa::mainloop::Threaded,
+pub struct NativeAudioEngine {
+	mlp: Pin<Box<pa::mainloop::Threaded>>,
 	context: pa::Context,
 	stream: pa::Stream,
 	_wh: Pin<Box<AudioDataWriter>>
 }
-impl NativeAudioEngine
-{
-	pub async fn new(mixer: &Arc<RwLock<peridot::audio::Mixer>>) -> Self
-	{
+impl NativeAudioEngine {
+	extern "C" fn state_callback(_: *mut pa::ffi::pa_context, user: *mut libc::c_void) {
+		let p = unsafe { &mut *(user as *mut pa::mainloop::Threaded) };
+		p.signal(false);
+	}
+	extern "C" fn stream_state_callback(_: *mut pa::ffi::pa_stream, user: *mut libc::c_void) {
+		let p = unsafe { &mut *(user as *mut pa::mainloop::Threaded) };
+		p.signal(false);
+	}
+	
+	pub fn new(mixer: &Arc<RwLock<peridot::audio::Mixer>>) -> Self {
 		info!("Starting AudioEngine via PulseAudio......");
 
-		let mut mlp = pa::mainloop::Threaded::new().expect("Failed to initialize PulseAudio Mainloop");
-		mlp.start().expect("Failed to start PulseAudio Mainloop");
-		let mut context = pa::Context::new(&mlp, "Peridot::NativeAudioEngine")
-			.expect("Failed to initialize PulseAudio context");
-		context.connect(None, pa::context::NOFLAGS, None).expect("Failed to connect PulseAudio server");
-		context.await_state_until(pa::context::State::Ready).await;
-
-		let spec = pa::SampleSpec
+		let mlp = Box::pin(pa::mainloop::Threaded::new().expect("Failed to initialize PulseAudio Mainloop"));
+		let (mut context, mut stream, writer);
 		{
-			format: pa::SampleFormat::FLOAT32LE as _,
-			rate: 44100,
-			channels: 2
-		};
-		let mut stream = context.new_stream("Peridot::NativeAudioEngine::Output", &spec, None)
-			.expect("Failed to initialize playback stream");
-		let mut writer = Box::pin(AudioDataWriter(mixer.clone()));
-		stream.set_write_request_callback(writer.as_mut());
-		let flags = pa::stream::AUTO_TIMING_UPDATE |
-			pa::stream::FIX_FORMAT |
-			pa::stream::FIX_RATE |
-			pa::stream::FIX_CHANNELS;
-		stream.connect_playback(None, None, flags, None, None).expect("Failed to connect playback stream");
-		stream.await_state_until(pa::stream::State::Ready).await;
-		info!("PulseAudio Sink Device = {}", stream.device_name());
+			let mut l = pa::mainloop::LockedLoop::new(Pin::into_inner(mlp.as_ref()));
+			context = pa::Context::new(&l, "Peridot::NativeAudioEngine")
+				.expect("Failed to initialize PulseAudio context");
+			context.set_state_callback(Some(Self::state_callback), Pin::into_inner(mlp.as_ref()) as *const _ as _);
+			context.connect(None, pa::context::NOFLAGS, None).expect("Failed to connect PulseAudio server");
+			l.start().expect("Failed to start PulseAudio Mainloop");
+			let mut current_state = context.state();
+			while current_state != pa::context::State::Ready {
+				l.wait();
+				current_state = context.state();
+			}
+
+			let spec = pa::SampleSpec
+			{
+				format: pa::SampleFormat::FLOAT32LE as _,
+				rate: 44100,
+				channels: 2
+			};
+			stream = context.new_stream("Peridot::NativeAudioEngine::Output", &spec, None)
+				.expect("Failed to initialize playback stream");
+			writer = Box::pin(AudioDataWriter {
+				mixer: mixer.clone(),
+				conv: RefCell::new(Box::new(0.0f32))
+			});
+			stream.set_write_request_callback(writer.as_ref());
+			stream.set_state_callback(Some(Self::stream_state_callback), Pin::into_inner(mlp.as_ref()) as *const _ as _);
+			let flags = pa::stream::AUTO_TIMING_UPDATE |
+				pa::stream::FIX_FORMAT |
+				pa::stream::FIX_RATE |
+				pa::stream::FIX_CHANNELS;
+			stream.connect_playback(None, None, flags, None, None).expect("Failed to connect playback stream");
+			let mut current_state = stream.state();
+			while current_state != pa::stream::State::Ready {
+				l.wait();
+				current_state = stream.state();
+			}
+			info!("PulseAudio Sink Device = {}", stream.device_name());
+			let ss = stream.sample_spec();
+			debug!("SampleSpec: {} {} {}", ss.format, ss.rate, ss.channels);
+			*writer.conv.borrow_mut() = if ss.format == pa::SampleFormat::S24LE as _ {
+				Box::new(SignedInt24LE)
+			} else {
+				panic!("pa: Unsupported sample format: {}", ss.format)
+			};
+		}
 
 		trace!("Done!");
 		NativeAudioEngine
@@ -74,7 +132,10 @@ impl Drop for NativeAudioEngine
 {
 	fn drop(&mut self)
 	{
-		self.stream.disconnect();
-		self.mlp.stop();
+		{
+			let _ = pa::mainloop::LockedLoop::new(Pin::into_inner(self.mlp.as_ref()));
+			self.stream.disconnect();
+		}
+		Pin::into_inner(self.mlp.as_mut()).stop();
 	}
 }

--- a/examples/image-plane/Cargo.toml
+++ b/examples/image-plane/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["S.Percentage <Syn.Tri.Naga@gmail.com>"]
 edition = "2018"
 
 [features]
-debug = ["bedrock/VK_EXT_debug_utils"]
+debug = ["bedrock/VK_EXT_debug_utils", "peridot/debug"]
 
 [dependencies]
 bedrock = { git = "https://github.com/Pctg-x8/bedrock", branch = "peridot" }


### PR DESCRIPTION
どうやら内部的にはfloat32じゃなくてsint24leを想定してたっぽいので、一旦それに対応する。

他はあとでいいや......

## 殘り

* [x] 終了時に謎に死んでしまう問題をなんとかする Thread落としてもstate_callback系がメッセージ送りつづけてるのが原因っぽそう