### PR TITLE
fix: no docs

### DIFF
--- a/modules/vg/src/font.rs
+++ b/modules/vg/src/font.rs
@@ -106,6 +106,9 @@ impl From<windows::core::Error> for GlyphLoadingError {
     }
 }
 
+/// Represents a font(layered on DirectWrite FontFace / FreeType Face)
+///
+/// For default implementation type, use `DefaultFont` type in some platforms.
 pub trait Font {
     type GlyphID;
 
@@ -127,6 +130,7 @@ pub trait Font {
     ) -> Result<(), GlyphLoadingError>;
 }
 
+#[cfg(not(doc))]
 pub type DefaultFont = <DefaultFontProvider as FontProvider>::Font;
 
 /// An asset represents ttf blob

--- a/modules/vg/src/font/provider.rs
+++ b/modules/vg/src/font/provider.rs
@@ -2,10 +2,15 @@ use cfg_if::cfg_if;
 
 use crate::{FontConstructionError, FontProperties};
 
+#[doc(hidden)]
 pub trait FontProviderConstruct: Sized + FontProvider {
     /// Creates font provider
     fn new() -> Result<Self, FontConstructionError>;
 }
+
+/// Represents Font Provider(layered on DirectWrite FontCollection / Fontconfig).
+///
+/// To use this functionality, `DefaultFontProvider` is exported for some platforms.
 pub trait FontProvider {
     /// Associated font type for this provider
     type Font: crate::Font;


### PR DESCRIPTION
DefaultFontProviderがdoc生成時は見つからないのでdocumentationしないようにする