### PR TITLE
ヘルパ系関数を追加/Bedrockアップデート対応

### DIFF
--- a/base/src/batch.rs
+++ b/base/src/batch.rs
@@ -1,7 +1,7 @@
 //! Batched Operation Helpers
 
 use crate::mthelper::{DynamicMut, DynamicMutabilityProvider, SharedRef};
-use bedrock as br;
+use bedrock::{self as br, ImageSubresourceSlice};
 use br::vk::VkBufferCopy;
 use br::{VkHandle, VulkanStructure};
 use log::*;
@@ -169,7 +169,7 @@ impl PartialEq for CopyBufferPair {
 impl Eq for CopyBufferPair {}
 
 pub struct TransferBatch2 {
-    copy_buffers: HashMap<CopyBufferPair, Vec<br::vk::VkBufferCopy>>,
+    copy_buffers: HashMap<CopyBufferPair, Vec<br::BufferCopy>>,
     src_transition_sets: HashSet<(TransferrableBufferResourceCompareCell, Range<u64>)>,
     before_transitions: HashMap<
         br::vk::VkPipelineStageFlags,
@@ -215,11 +215,14 @@ impl TransferBatch2 {
         self.copy_buffers
             .entry(CopyBufferPair(Box::new(src.clone()), Box::new(dst)))
             .or_insert_with(Vec::new)
-            .push(br::vk::VkBufferCopy {
-                srcOffset: src_offset,
-                dstOffset: dst_offset,
-                size: byte_length,
-            });
+            .push(
+                br::vk::VkBufferCopy {
+                    srcOffset: src_offset,
+                    dstOffset: dst_offset,
+                    size: byte_length,
+                }
+                .into(),
+            );
         self.src_transition_sets.insert((
             TransferrableBufferResourceCompareCell(Box::new(src)),
             src_offset..src_offset + byte_length,
@@ -263,11 +266,15 @@ impl TransferBatch2 {
         self.register_after_transition(pipeline_stage, res, range, access_mask);
     }
 
-    pub fn generate_commands(
+    pub fn generate_commands<
+        'r,
+        CB: br::VkHandleMut<Handle = br::vk::VkCommandBuffer> + ?Sized,
+        Device: br::Device,
+    >(
         &self,
-        rec: &mut br::CmdRecord<impl br::VkHandleMut<Handle = br::vk::VkCommandBuffer> + ?Sized>,
-    ) {
-        let _ = rec.pipeline_barrier(
+        rec: br::CmdRecord<'r, CB, Device>,
+    ) -> br::CmdRecord<'r, CB, Device> {
+        rec.pipeline_barrier(
             br::PipelineStageFlags::HOST,
             br::PipelineStageFlags::TRANSFER,
             false,
@@ -290,66 +297,72 @@ impl TransferBatch2 {
                 })
                 .collect::<Vec<_>>(),
             &[],
-        );
-        for (&p, trans) in self.before_transitions.iter() {
-            let _ = rec.pipeline_barrier(
-                br::PipelineStageFlags(p),
-                br::PipelineStageFlags::TRANSFER,
-                false,
-                &[],
-                &trans
-                    .iter()
-                    .map(|(res, range, a)| {
-                        br::BufferMemoryBarrier::from(br::vk::VkBufferMemoryBarrier {
-                            sType: br::vk::VkBufferMemoryBarrier::TYPE,
-                            pNext: core::ptr::null(),
-                            srcAccessMask: *a,
-                            dstAccessMask: br::AccessFlags::TRANSFER.write,
-                            srcQueueFamilyIndex: br::vk::VK_QUEUE_FAMILY_IGNORED,
-                            dstQueueFamilyIndex: br::vk::VK_QUEUE_FAMILY_IGNORED,
-                            buffer: res.raw_handle(),
-                            offset: range.start,
-                            size: range.end - range.start,
+        )
+        .inject(|r| {
+            self.before_transitions.iter().fold(r, |r, (&p, trans)| {
+                r.pipeline_barrier(
+                    br::PipelineStageFlags(p),
+                    br::PipelineStageFlags::TRANSFER,
+                    false,
+                    &[],
+                    &trans
+                        .iter()
+                        .map(|(res, range, a)| {
+                            br::BufferMemoryBarrier::from(br::vk::VkBufferMemoryBarrier {
+                                sType: br::vk::VkBufferMemoryBarrier::TYPE,
+                                pNext: core::ptr::null(),
+                                srcAccessMask: *a,
+                                dstAccessMask: br::AccessFlags::TRANSFER.write,
+                                srcQueueFamilyIndex: br::vk::VK_QUEUE_FAMILY_IGNORED,
+                                dstQueueFamilyIndex: br::vk::VK_QUEUE_FAMILY_IGNORED,
+                                buffer: res.raw_handle(),
+                                offset: range.start,
+                                size: range.end - range.start,
+                            })
                         })
-                    })
-                    .collect::<Vec<_>>(),
-                &[],
-            );
-        }
-
-        for (CopyBufferPair(src, dst), ranges) in self.copy_buffers.iter() {
-            let _ = rec.copy_buffer(
-                &unsafe { br::VkHandleRef::dangling(src.raw_handle()) },
-                &unsafe { br::VkHandleRef::dangling(dst.raw_handle()) },
-                &ranges,
-            );
-        }
-
-        for (&p, ts) in self.after_transitions.iter() {
-            let _ = rec.pipeline_barrier(
-                br::PipelineStageFlags::TRANSFER,
-                br::PipelineStageFlags(p),
-                false,
-                &[],
-                &ts.iter()
-                    .map(|(res, range, a)| {
-                        br::BufferMemoryBarrier::from(br::vk::VkBufferMemoryBarrier {
-                            sType: br::vk::VkBufferMemoryBarrier::TYPE,
-                            pNext: core::ptr::null(),
-                            srcAccessMask: br::AccessFlags::TRANSFER.write,
-                            dstAccessMask: *a,
-                            srcQueueFamilyIndex: br::vk::VK_QUEUE_FAMILY_IGNORED,
-                            dstQueueFamilyIndex: br::vk::VK_QUEUE_FAMILY_IGNORED,
-                            buffer: res.raw_handle(),
-                            offset: range.start,
-                            size: range.end - range.start,
+                        .collect::<Vec<_>>(),
+                    &[],
+                )
+            })
+        })
+        .inject(|r| {
+            self.copy_buffers
+                .iter()
+                .fold(r, |r, (CopyBufferPair(src, dst), ranges)| {
+                    r.copy_buffer(
+                        &unsafe { br::VkHandleRef::dangling(src.raw_handle()) },
+                        &unsafe { br::VkHandleRef::dangling(dst.raw_handle()) },
+                        &ranges,
+                    )
+                })
+        })
+        .inject(|r| {
+            self.after_transitions.iter().fold(r, |r, (&p, ts)| {
+                r.pipeline_barrier(
+                    br::PipelineStageFlags::TRANSFER,
+                    br::PipelineStageFlags(p),
+                    false,
+                    &[],
+                    &ts.iter()
+                        .map(|(res, range, a)| {
+                            br::BufferMemoryBarrier::from(br::vk::VkBufferMemoryBarrier {
+                                sType: br::vk::VkBufferMemoryBarrier::TYPE,
+                                pNext: core::ptr::null(),
+                                srcAccessMask: br::AccessFlags::TRANSFER.write,
+                                dstAccessMask: *a,
+                                srcQueueFamilyIndex: br::vk::VK_QUEUE_FAMILY_IGNORED,
+                                dstQueueFamilyIndex: br::vk::VK_QUEUE_FAMILY_IGNORED,
+                                buffer: res.raw_handle(),
+                                offset: range.start,
+                                size: range.end - range.start,
+                            })
                         })
-                    })
-                    .collect::<Vec<_>>(),
-                &[],
-            );
-        }
-        let _ = rec.pipeline_barrier(
+                        .collect::<Vec<_>>(),
+                    &[],
+                )
+            })
+        })
+        .pipeline_barrier(
             br::PipelineStageFlags::TRANSFER,
             br::PipelineStageFlags::HOST,
             false,
@@ -372,7 +385,7 @@ impl TransferBatch2 {
                 })
                 .collect::<Vec<_>>(),
             &[],
-        );
+        )
     }
 }
 
@@ -382,8 +395,10 @@ pub struct TransferBatch<Device: br::Device = super::DeviceObject> {
     barrier_range_dst: BTreeMap<ResourceKey<br::vk::VkBuffer>, Range<br::vk::VkDeviceSize>>,
     org_layout_src: BTreeMap<ImageKey<Device>, br::ImageLayout>,
     org_layout_dst: BTreeMap<ImageKey<Device>, br::ImageLayout>,
-    copy_buffers:
-        HashMap<(ResourceKey<br::vk::VkBuffer>, ResourceKey<br::vk::VkBuffer>), Vec<VkBufferCopy>>,
+    copy_buffers: HashMap<
+        (ResourceKey<br::vk::VkBuffer>, ResourceKey<br::vk::VkBuffer>),
+        Vec<br::BufferCopy>,
+    >,
     init_images: BTreeMap<
         ImageKey<Device>,
         (
@@ -439,11 +454,14 @@ impl<Device: br::Device> TransferBatch<Device> {
         self.copy_buffers
             .entry((ResourceKey(src.buffer), ResourceKey(dst.buffer)))
             .or_insert_with(Vec::new)
-            .push(VkBufferCopy {
-                srcOffset: src.offset,
-                dstOffset: dst.offset,
-                size: bytes,
-            });
+            .push(
+                VkBufferCopy {
+                    srcOffset: src.offset,
+                    dstOffset: dst.offset,
+                    size: bytes,
+                }
+                .into(),
+            );
     }
 
     /// Add copying operation between buffers.
@@ -551,10 +569,10 @@ impl<Device: br::Device> TransferBatch<Device> {
 }
 /// Sinking Commands into CommandBuffers
 impl<Device: br::Device> TransferBatch<Device> {
-    pub fn sink_transfer_commands(
+    pub fn sink_transfer_commands<'r, CB: br::CommandBuffer + br::VkHandleMut + ?Sized>(
         &self,
-        r: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut>,
-    ) {
+        r: br::CmdRecord<'r, CB, Device>,
+    ) -> br::CmdRecord<'r, CB, Device> {
         let src_barriers = self.barrier_range_src.iter().map(|(b, r)| {
             br::BufferMemoryBarrier::new(
                 &b.0,
@@ -568,115 +586,96 @@ impl<Device: br::Device> TransferBatch<Device> {
         });
         let barriers: Vec<_> = src_barriers.chain(dst_barriers).collect();
         let src_barriers_i = self.org_layout_src.iter().map(|(b, &l0)| {
-            br::ImageMemoryBarrier::new(
-                &b.0,
-                br::vk::VkImageSubresourceRange {
-                    aspectMask: br::AspectMask::COLOR.0,
-                    baseMipLevel: 0,
-                    levelCount: 1,
-                    baseArrayLayer: 0,
-                    layerCount: 1,
-                },
-                l0,
-                br::ImageLayout::TransferSrcOpt,
-            )
+            b.0.by_ref()
+                .subresource_range(br::AspectMask::COLOR, 0..1, 0..1)
+                .memory_barrier(l0.to(br::ImageLayout::TransferSrcOpt))
         });
         let dst_barriers_i = self.org_layout_dst.iter().map(|(b, &l0)| {
-            br::ImageMemoryBarrier::new(
-                &b.0,
-                br::vk::VkImageSubresourceRange {
-                    aspectMask: br::AspectMask::COLOR.0,
-                    baseMipLevel: 0,
-                    levelCount: 1,
-                    baseArrayLayer: 0,
-                    layerCount: 1,
-                },
-                l0,
-                br::ImageLayout::TransferDestOpt,
-            )
+            b.0.by_ref()
+                .subresource_range(br::AspectMask::COLOR, 0..1, 0..1)
+                .memory_barrier(l0.to(br::ImageLayout::TransferDestOpt))
         });
         let barriers_i: Vec<_> = src_barriers_i.chain(dst_barriers_i).collect();
 
-        let _ = r.pipeline_barrier(
+        r.pipeline_barrier(
             br::PipelineStageFlags::HOST,
             br::PipelineStageFlags::TRANSFER,
             false,
             &[],
             &barriers,
             &barriers_i,
-        );
-        for (&(ref s, ref d), ref rs) in &self.copy_buffers {
-            let _ = r.copy_buffer(&s.0, &d.0, &rs);
-        }
-        for (d, (dex, s, so)) in &self.init_images {
-            trace!("Copying Image: extent={dex:?}");
+        )
+        .inject(|r| {
+            self.copy_buffers
+                .iter()
+                .fold(r, |r, ((s, d), rs)| r.copy_buffer(&s.0, &d.0, &rs))
+        })
+        .inject(|r| {
+            self.init_images.iter().fold(r, |r, (d, (dex, s, so))| {
+                trace!("Copying Image: extent={dex:?}");
 
-            let _ = r.copy_buffer_to_image(
-                &s,
-                &d.0,
-                br::ImageLayout::TransferDestOpt,
-                &[br::vk::VkBufferImageCopy {
-                    bufferOffset: *so,
-                    bufferRowLength: 0,
-                    bufferImageHeight: 0,
-                    // TODO: これもいじれるようにしたほうがいいんだろうか......
-                    imageSubresource: br::vk::VkImageSubresourceLayers {
-                        aspectMask: br::vk::VK_IMAGE_ASPECT_COLOR_BIT,
-                        mipLevel: 0,
-                        baseArrayLayer: 0,
-                        layerCount: 1,
-                    },
-                    imageOffset: br::vk::VkOffset3D { x: 0, y: 0, z: 0 },
-                    imageExtent: dex.clone(),
-                }],
-            );
-        }
+                r.copy_buffer_to_image(
+                    &s,
+                    &d.0,
+                    br::ImageLayout::TransferDestOpt,
+                    &[br::vk::VkBufferImageCopy {
+                        bufferOffset: *so,
+                        bufferRowLength: 0,
+                        bufferImageHeight: 0,
+                        // TODO: これもいじれるようにしたほうがいいんだろうか......
+                        imageSubresource: br::vk::VkImageSubresourceLayers {
+                            aspectMask: br::vk::VK_IMAGE_ASPECT_COLOR_BIT,
+                            mipLevel: 0,
+                            baseArrayLayer: 0,
+                            layerCount: 1,
+                        },
+                        imageOffset: br::vk::VkOffset3D { x: 0, y: 0, z: 0 },
+                        imageExtent: dex.clone(),
+                    }],
+                )
+            })
+        })
     }
 
-    pub fn sink_graphics_ready_commands(
+    pub fn sink_graphics_ready_commands<'r, CB: br::CommandBuffer + br::VkHandleMut + ?Sized>(
         &self,
-        r: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut>,
-    ) {
-        for (
-            &stg,
-            &ReadyResourceBarriers {
-                ref buffer,
-                ref image,
-                ..
+        r: br::CmdRecord<'r, CB, Device>,
+    ) -> br::CmdRecord<'r, CB, Device> {
+        self.ready_barriers.iter().fold(
+            r,
+            |r, (stg, ReadyResourceBarriers { buffer, image, .. })| {
+                let buf_barriers: Vec<_> = buffer
+                    .iter()
+                    .map(|&(ref r, ref br, a)| {
+                        br::BufferMemoryBarrier::new(
+                            &r,
+                            br.start as _..br.end as _,
+                            br::AccessFlags::TRANSFER.read,
+                            a,
+                        )
+                    })
+                    .collect();
+                let img_barriers: Vec<_> = image
+                    .iter()
+                    .map(|(r, range, l)| {
+                        br::ImageMemoryBarrier::new(
+                            r,
+                            range.clone(),
+                            br::ImageLayout::TransferDestOpt.to(*l),
+                        )
+                    })
+                    .collect();
+
+                r.pipeline_barrier(
+                    br::PipelineStageFlags::TRANSFER,
+                    *stg,
+                    false,
+                    &[],
+                    &buf_barriers,
+                    &img_barriers,
+                )
             },
-        ) in &self.ready_barriers
-        {
-            let buf_barriers: Vec<_> = buffer
-                .iter()
-                .map(|&(ref r, ref br, a)| {
-                    br::BufferMemoryBarrier::new(
-                        &r,
-                        br.start as _..br.end as _,
-                        br::AccessFlags::TRANSFER.read,
-                        a,
-                    )
-                })
-                .collect();
-            let img_barriers: Vec<_> = image
-                .iter()
-                .map(|(r, range, l)| {
-                    br::ImageMemoryBarrier::new(
-                        &r,
-                        range.clone(),
-                        br::ImageLayout::TransferDestOpt,
-                        *l,
-                    )
-                })
-                .collect();
-            let _ = r.pipeline_barrier(
-                br::PipelineStageFlags::TRANSFER,
-                stg,
-                false,
-                &[],
-                &buf_barriers,
-                &img_barriers,
-            );
-        }
+        )
     }
 }
 

--- a/base/src/graphics.rs
+++ b/base/src/graphics.rs
@@ -226,14 +226,15 @@ impl Graphics {
     pub fn submit_commands(
         &mut self,
         generator: impl FnOnce(
-            br::CmdRecord<br::CommandBufferObject<DeviceObject>>,
-        ) -> br::CmdRecord<br::CommandBufferObject<DeviceObject>>,
+            br::CmdRecord<br::CommandBufferObject<DeviceObject>, DeviceObject>,
+        )
+            -> br::CmdRecord<br::CommandBufferObject<DeviceObject>, DeviceObject>,
     ) -> br::Result<()> {
         let mut cb = LocalCommandBundle(
             self.cp_onetime_submit.alloc(1, true)?,
             &mut self.cp_onetime_submit,
         );
-        generator(unsafe { cb[0].begin_once()? }).end()?;
+        generator(unsafe { cb[0].begin_once(&self.device)? }).end()?;
         self.graphics_queue.q.get_mut().submit(
             &[br::EmptySubmissionBatch.with_command_buffers(&cb[..])],
             None::<&mut br::FenceObject<DeviceObject>>,
@@ -265,8 +266,9 @@ impl Graphics {
     pub fn submit_commands_async<'s>(
         &'s self,
         generator: impl FnOnce(
-            br::CmdRecord<br::CommandBufferObject<DeviceObject>>,
-        ) -> br::CmdRecord<br::CommandBufferObject<DeviceObject>>,
+            br::CmdRecord<br::CommandBufferObject<DeviceObject>, DeviceObject>,
+        )
+            -> br::CmdRecord<br::CommandBufferObject<DeviceObject>, DeviceObject>,
     ) -> br::Result<impl std::future::Future<Output = br::Result<()>> + 's> {
         let mut fence = std::sync::Arc::new(br::FenceBuilder::new().create(self.device.clone())?);
 
@@ -274,7 +276,7 @@ impl Graphics {
             .transient()
             .create(self.device.clone())?;
         let mut cb = CommandBundle(pool.alloc(1, true)?, pool);
-        generator(unsafe { cb[0].begin_once()? }).end()?;
+        generator(unsafe { cb[0].begin_once(&self.device)? }).end()?;
         self.graphics_queue.q.lock().submit(
             &[br::EmptySubmissionBatch.with_command_buffers(&cb[..])],
             Some(unsafe { std::sync::Arc::get_mut(&mut fence).unwrap_unchecked() }),

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -208,11 +208,8 @@ impl<PL: NativeLinker> Engine<PL> {
         )
         .expect("Failed to initialize Graphics Base Driver");
         let presenter = native_link.new_presenter(&g);
-        g.submit_commands(|mut r| {
-            presenter.emit_initialize_back_buffer_commands(&mut r);
-            r
-        })
-        .expect("Initializing Back Buffers");
+        g.submit_commands(|r| presenter.emit_initialize_back_buffer_commands(r))
+            .expect("Initializing Back Buffers");
 
         Self {
             ip: InputProcess::new().into(),
@@ -288,8 +285,9 @@ impl<NL: NativeLinker> Engine<NL> {
     pub fn submit_commands(
         &mut self,
         generator: impl FnOnce(
-            br::CmdRecord<br::CommandBufferObject<DeviceObject>>,
-        ) -> br::CmdRecord<br::CommandBufferObject<DeviceObject>>,
+            br::CmdRecord<br::CommandBufferObject<DeviceObject>, DeviceObject>,
+        )
+            -> br::CmdRecord<br::CommandBufferObject<DeviceObject>, DeviceObject>,
     ) -> br::Result<()> {
         self.g.submit_commands(generator)
     }
@@ -308,8 +306,9 @@ impl<NL: NativeLinker> Engine<NL> {
     pub fn submit_commands_async<'s>(
         &'s self,
         generator: impl FnOnce(
-                br::CmdRecord<br::CommandBufferObject<DeviceObject>>,
-            ) -> br::CmdRecord<br::CommandBufferObject<DeviceObject>>
+                br::CmdRecord<br::CommandBufferObject<DeviceObject>, DeviceObject>,
+            )
+                -> br::CmdRecord<br::CommandBufferObject<DeviceObject>, DeviceObject>
             + 's,
     ) -> br::Result<impl std::future::Future<Output = br::Result<()>> + 's> {
         self.g.submit_commands_async(generator)
@@ -402,10 +401,7 @@ impl<PL: NativeLinker> Engine<PL> {
             let pres = &self.presenter;
 
             self.g
-                .submit_commands(|mut r| {
-                    pres.emit_initialize_back_buffer_commands(&mut r);
-                    r
-                })
+                .submit_commands(|r| pres.emit_initialize_back_buffer_commands(r))
                 .expect("Initializing Back Buffers");
         }
         callback.on_resize(self, new_size);
@@ -568,10 +564,15 @@ impl<Pipeline: br::Pipeline, Layout: br::PipelineLayout> LayoutedPipeline<Pipeli
         &self.1
     }
 
-    pub fn bind(
+    #[inline(always)]
+    pub fn bind<
+        'r,
+        CB: br::VkHandleMut<Handle = br::vk::VkCommandBuffer> + ?Sized,
+        Device: br::Device + ?Sized,
+    >(
         &self,
-        rec: &mut br::CmdRecord<impl br::VkHandleMut<Handle = br::vk::VkCommandBuffer> + ?Sized>,
-    ) {
-        let _ = rec.bind_graphics_pipeline_pair(&self.0, &self.1);
+        rec: br::CmdRecord<'r, CB, Device>,
+    ) -> br::CmdRecord<'r, CB, Device> {
+        rec.bind_graphics_pipeline_pair(&self.0, &self.1)
     }
 }

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -18,13 +18,17 @@ pub trait ModelData {
 pub trait DefaultRenderCommands<'e, Device: br::Device> {
     type Extras: 'e;
 
-    fn default_render_commands<NL: NativeLinker>(
+    fn default_render_commands<
+        'r,
+        NL: NativeLinker,
+        CB: br::VkHandleMut<Handle = br::vk::VkCommandBuffer> + ?Sized,
+    >(
         &self,
         e: &Engine<NL>,
-        cmd: &mut br::CmdRecord<impl br::VkHandleMut<Handle = br::vk::VkCommandBuffer> + ?Sized>,
+        cmd: br::CmdRecord<'r, CB, Device>,
         buffer: &(impl br::Buffer<ConcreteDevice = Device> + ?Sized),
         extras: Self::Extras,
-    );
+    ) -> br::CmdRecord<'r, CB, Device>;
 }
 
 #[derive(Debug, Clone)]

--- a/base/src/presenter.rs
+++ b/base/src/presenter.rs
@@ -17,14 +17,10 @@ pub trait PlatformPresenter {
     fn back_buffer_count(&self) -> usize;
     fn back_buffer(&self, index: usize) -> Option<SharedRef<Self::BackBuffer>>;
 
-    fn emit_initialize_back_buffer_commands<
-        'r,
-        CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
-        Device: br::Device,
-    >(
+    fn emit_initialize_back_buffer_commands<'r, CB: br::CommandBuffer + br::VkHandleMut + ?Sized>(
         &self,
-        recorder: br::CmdRecord<'r, CB, Device>,
-    ) -> br::CmdRecord<'r, CB, Device>;
+        recorder: br::CmdRecord<'r, CB, DeviceObject>,
+    ) -> br::CmdRecord<'r, CB, DeviceObject>;
     fn next_back_buffer_index(&mut self) -> br::Result<u32>;
     fn requesting_back_buffer_layout(&self) -> (br::ImageLayout, br::PipelineStageFlags);
     fn render_and_present<'s>(
@@ -228,11 +224,10 @@ impl<Surface: br::Surface> IntegratedSwapchain<Surface> {
     pub fn emit_initialize_back_buffer_commands<
         'r,
         CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
-        Device: br::Device + ?Sized,
     >(
         &self,
-        recorder: br::CmdRecord<'r, CB, Device>,
-    ) -> br::CmdRecord<'r, CB, Device> {
+        recorder: br::CmdRecord<'r, CB, DeviceObject>,
+    ) -> br::CmdRecord<'r, CB, DeviceObject> {
         let image_barriers = self
             .swapchain
             .get()

--- a/base/src/presenter.rs
+++ b/base/src/presenter.rs
@@ -17,10 +17,14 @@ pub trait PlatformPresenter {
     fn back_buffer_count(&self) -> usize;
     fn back_buffer(&self, index: usize) -> Option<SharedRef<Self::BackBuffer>>;
 
-    fn emit_initialize_back_buffer_commands(
+    fn emit_initialize_back_buffer_commands<
+        'r,
+        CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
+        Device: br::Device,
+    >(
         &self,
-        recorder: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut + ?Sized>,
-    );
+        recorder: br::CmdRecord<'r, CB, Device>,
+    ) -> br::CmdRecord<'r, CB, Device>;
     fn next_back_buffer_index(&mut self) -> br::Result<u32>;
     fn requesting_back_buffer_layout(&self) -> (br::ImageLayout, br::PipelineStageFlags);
     fn render_and_present<'s>(
@@ -221,39 +225,34 @@ impl<Surface: br::Surface> IntegratedSwapchain<Surface> {
         self.swapchain.get().back_buffer_images.get(index).cloned()
     }
 
-    pub fn emit_initialize_back_buffer_commands(
+    pub fn emit_initialize_back_buffer_commands<
+        'r,
+        CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
+        Device: br::Device,
+    >(
         &self,
-        recorder: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut + ?Sized>,
-    ) {
+        recorder: br::CmdRecord<'r, CB, Device>,
+    ) -> br::CmdRecord<'r, CB, Device> {
         let image_barriers = self
             .swapchain
             .get()
             .back_buffer_images
             .iter()
             .map(|v| {
-                br::ImageMemoryBarrier::new(
-                    &***v,
-                    br::vk::VkImageSubresourceRange {
-                        aspectMask: br::AspectMask::COLOR.0,
-                        baseMipLevel: 0,
-                        levelCount: 1,
-                        baseArrayLayer: 0,
-                        layerCount: 1,
-                    },
-                    br::ImageLayout::Undefined,
-                    br::ImageLayout::PresentSrc,
-                )
+                v.by_ref()
+                    .subresource_range(br::AspectMask::COLOR, 0..1, 0..1)
+                    .memory_barrier(br::ImageLayout::PresentSrc.from_undefined())
             })
             .collect::<Vec<_>>();
 
-        let _ = recorder.pipeline_barrier(
+        recorder.pipeline_barrier(
             br::PipelineStageFlags::BOTTOM_OF_PIPE,
             br::PipelineStageFlags::BOTTOM_OF_PIPE,
             false,
             &[],
             &[],
             &image_barriers,
-        );
+        )
     }
 
     #[inline]

--- a/base/src/presenter.rs
+++ b/base/src/presenter.rs
@@ -228,7 +228,7 @@ impl<Surface: br::Surface> IntegratedSwapchain<Surface> {
     pub fn emit_initialize_back_buffer_commands<
         'r,
         CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
-        Device: br::Device,
+        Device: br::Device + ?Sized,
     >(
         &self,
         recorder: br::CmdRecord<'r, CB, Device>,

--- a/base/src/resource.rs
+++ b/base/src/resource.rs
@@ -65,12 +65,10 @@ impl<Device: br::Device> Texture2D<br::ImageObject<Device>> {
         format: PixelFormat,
         prealloc: &mut BufferPrealloc,
     ) -> br::Result<(br::ImageObject<Device>, u64)> {
-        let idesc = br::ImageDesc::new(
-            size.clone(),
-            format as _,
-            br::ImageUsageFlags::SAMPLED | br::ImageUsageFlags::TRANSFER_DEST,
-            br::ImageLayout::Preinitialized,
-        );
+        let idesc = br::ImageDesc::new(size.clone(), format as _)
+            .sampled()
+            .transfer_dest()
+            .init_layout(br::ImageLayout::Preinitialized);
         let bytes_per_pixel = (format.bpp() >> 3) as u64;
         let pixels_stg = prealloc.add(BufferContent::Raw(
             (size.x() * size.y()) as u64 * bytes_per_pixel,
@@ -426,12 +424,11 @@ impl DeviceWorkingTextureAllocator<'_> {
         format: PixelFormat,
         usage: br::ImageUsageFlags,
     ) -> DeviceWorkingTexture2DRef {
-        self.planes.push(br::ImageDesc::new(
-            size,
-            format as _,
-            usage,
-            br::ImageLayout::Preinitialized,
-        ));
+        self.planes.push(
+            br::ImageDesc::new(size, format as _)
+                .usage_with(usage)
+                .init_layout(br::ImageLayout::Preinitialized),
+        );
         DeviceWorkingTexture2DRef(self.planes.len() - 1)
     }
 
@@ -442,12 +439,11 @@ impl DeviceWorkingTextureAllocator<'_> {
         format: PixelFormat,
         usage: br::ImageUsageFlags,
     ) -> DeviceWorkingTexture3DRef {
-        self.volumes.push(br::ImageDesc::new(
-            size,
-            format as _,
-            usage,
-            br::ImageLayout::Preinitialized,
-        ));
+        self.volumes.push(
+            br::ImageDesc::new(size, format as _)
+                .usage_with(usage)
+                .init_layout(br::ImageLayout::Preinitialized),
+        );
         DeviceWorkingTexture3DRef(self.volumes.len() - 1)
     }
 
@@ -458,7 +454,9 @@ impl DeviceWorkingTextureAllocator<'_> {
         format: PixelFormat,
         usage: br::ImageUsageFlags,
     ) -> DeviceWorkingCubeTextureRef {
-        let id = br::ImageDesc::new(size, format as _, usage, br::ImageLayout::Preinitialized)
+        let id = br::ImageDesc::new(size, format as _)
+            .usage_with(usage)
+            .init_layout(br::ImageLayout::Preinitialized)
             .flags(br::ImageFlags::CUBE_COMPATIBLE)
             .array_layers(6);
         self.cube.push(id);
@@ -474,7 +472,9 @@ impl DeviceWorkingTextureAllocator<'_> {
         usage: br::ImageUsageFlags,
         mipmaps: u32,
     ) -> DeviceWorkingCubeTextureRef {
-        let id = br::ImageDesc::new(size, format as _, usage, br::ImageLayout::Preinitialized)
+        let id = br::ImageDesc::new(size, format as _)
+            .usage_with(usage)
+            .init_layout(br::ImageLayout::Preinitialized)
             .flags(br::ImageFlags::CUBE_COMPATIBLE)
             .array_layers(6)
             .mip_levels(mipmaps);

--- a/cradle/android/src/lib.rs
+++ b/cradle/android/src/lib.rs
@@ -103,10 +103,13 @@ impl peridot::PlatformPresenter for Presenter {
         self.sc.back_buffer(index)
     }
 
-    fn emit_initialize_back_buffer_commands(
+    fn emit_initialize_back_buffer_commands<
+        'r,
+        CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
+    >(
         &self,
-        recorder: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut + ?Sized>,
-    ) {
+        recorder: br::CmdRecord<'r, CB, peridot::DeviceObject>,
+    ) -> br::CmdRecord<'r, CB, peridot::DeviceObject> {
         self.sc.emit_initialize_back_buffer_commands(recorder)
     }
     fn next_back_buffer_index(&mut self) -> br::Result<u32> {

--- a/cradle/linux/src/presenter/wayland.rs
+++ b/cradle/linux/src/presenter/wayland.rs
@@ -350,10 +350,13 @@ impl peridot::PlatformPresenter for Presenter {
         self.sc.requesting_back_buffer_layout()
     }
 
-    fn emit_initialize_back_buffer_commands(
+    fn emit_initialize_back_buffer_commands<
+        'r,
+        CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
+    >(
         &self,
-        recorder: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut + ?Sized>,
-    ) {
+        recorder: br::CmdRecord<'r, CB, peridot::DeviceObject>,
+    ) -> br::CmdRecord<'r, CB, peridot::DeviceObject> {
         self.sc.emit_initialize_back_buffer_commands(recorder)
     }
     fn next_back_buffer_index(&mut self) -> br::Result<u32> {

--- a/cradle/linux/src/presenter/xcb.rs
+++ b/cradle/linux/src/presenter/xcb.rs
@@ -291,10 +291,13 @@ impl peridot::PlatformPresenter for Presenter {
         self.sc.requesting_back_buffer_layout()
     }
 
-    fn emit_initialize_back_buffer_commands(
+    fn emit_initialize_back_buffer_commands<
+        'r,
+        CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
+    >(
         &self,
-        recorder: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut + ?Sized>,
-    ) {
+        recorder: br::CmdRecord<'r, CB, peridot::DeviceObject>,
+    ) -> br::CmdRecord<'r, CB, peridot::DeviceObject> {
         self.sc.emit_initialize_back_buffer_commands(recorder)
     }
     fn next_back_buffer_index(&mut self) -> br::Result<u32> {

--- a/cradle/mac/src/lib.rs
+++ b/cradle/mac/src/lib.rs
@@ -237,10 +237,13 @@ impl peridot::PlatformPresenter for Presenter {
         self.sc.requesting_back_buffer_layout()
     }
 
-    fn emit_initialize_back_buffer_commands(
+    fn emit_initialize_back_buffer_commands<
+        'r,
+        CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
+    >(
         &self,
-        recorder: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut + ?Sized>,
-    ) {
+        recorder: br::CmdRecord<'r, CB: peridot::DeviceObject>,
+    ) -> br::CmdRecord<'r, CB, peridot::DeviceObject> {
         self.sc.emit_initialize_back_buffer_commands(recorder);
     }
     fn next_back_buffer_index(&mut self) -> br::Result<u32> {

--- a/cradle/mac/src/lib.rs
+++ b/cradle/mac/src/lib.rs
@@ -244,7 +244,7 @@ impl peridot::PlatformPresenter for Presenter {
         &self,
         recorder: br::CmdRecord<'r, CB: peridot::DeviceObject>,
     ) -> br::CmdRecord<'r, CB, peridot::DeviceObject> {
-        self.sc.emit_initialize_back_buffer_commands(recorder);
+        self.sc.emit_initialize_back_buffer_commands(recorder)
     }
     fn next_back_buffer_index(&mut self) -> br::Result<u32> {
         self.sc.acquire_next_back_buffer_index()

--- a/cradle/mac/src/lib.rs
+++ b/cradle/mac/src/lib.rs
@@ -242,7 +242,7 @@ impl peridot::PlatformPresenter for Presenter {
         CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
     >(
         &self,
-        recorder: br::CmdRecord<'r, CB: peridot::DeviceObject>,
+        recorder: br::CmdRecord<'r, CB, peridot::DeviceObject>,
     ) -> br::CmdRecord<'r, CB, peridot::DeviceObject> {
         self.sc.emit_initialize_back_buffer_commands(recorder)
     }

--- a/cradle/windows/src/presenter.rs
+++ b/cradle/windows/src/presenter.rs
@@ -88,10 +88,14 @@ impl peridot::PlatformPresenter for Presenter {
         self.sc.back_buffer(index)
     }
 
-    fn emit_initialize_back_buffer_commands(
+    fn emit_initialize_back_buffer_commands<
+        'r,
+        CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
+        Device: br::Device + ?Sized,
+    >(
         &self,
-        recorder: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut + ?Sized>,
-    ) {
+        recorder: br::CmdRecord<'r, CB, Device>,
+    ) -> br::CmdRecord<'r, CB, Device> {
         self.sc.emit_initialize_back_buffer_commands(recorder)
     }
     fn next_back_buffer_index(&mut self) -> br::Result<u32> {
@@ -230,15 +234,12 @@ impl InteropBackbufferResource {
         });
         let vk_shared_handle =
             br::ExternalMemoryHandleTypeWin32::D3D12Resource.with_handle(shared_handle.handle());
-        let image = br::ImageDesc::new(
-            size,
-            format,
-            br::ImageUsageFlags::COLOR_ATTACHMENT,
-            br::ImageLayout::Preinitialized,
-        )
-        .exportable_as(vk_shared_handle.0.into())
-        .create(g.device().clone())
-        .expect("Failed to create Interop Image");
+        let image = br::ImageDesc::new(size, format)
+            .as_color_attachment()
+            .init_layout(br::ImageLayout::Preinitialized)
+            .exportable_as(vk_shared_handle.0.into())
+            .create(g.device().clone())
+            .expect("Failed to create Interop Image");
         let image_mreq = image.requirements();
         let handle_import_props = unsafe {
             vk_shared_handle
@@ -255,7 +256,7 @@ impl InteropBackbufferResource {
             .index();
         let memory = SharedRef::new(
             vk_shared_handle
-                .into_import_request(memory_type_index, &hname)
+                .into_import_request(memory_type_index, Some(&hname))
                 .execute(g.device().clone())
                 .expect("Failed to import memory")
                 .into(),
@@ -508,10 +509,14 @@ impl peridot::PlatformPresenter for Presenter {
         self.back_buffers.get(index).map(|b| b.image_view.clone())
     }
 
-    fn emit_initialize_back_buffer_commands(
+    fn emit_initialize_back_buffer_commands<
+        'r,
+        CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
+        Device: br::Device + ?Sized,
+    >(
         &self,
-        recorder: &mut br::CmdRecord<impl br::CommandBuffer + br::VkHandleMut + ?Sized>,
-    ) {
+        recorder: br::CmdRecord<'r, CB, Device>,
+    ) -> br::CmdRecord<'r, CB, Device> {
         let barriers = self
             .back_buffers
             .iter()
@@ -519,18 +524,18 @@ impl peridot::PlatformPresenter for Presenter {
                 b.image_view
                     .image()
                     .subresource_range(br::AspectMask::COLOR, 0..1, 0..1)
-                    .memory_barrier(br::ImageLayout::Preinitialized, br::ImageLayout::General)
+                    .memory_barrier(br::ImageLayout::Preinitialized.to(br::ImageLayout::General))
             })
             .collect::<Vec<_>>();
 
-        let _ = recorder.pipeline_barrier(
+        recorder.pipeline_barrier(
             br::PipelineStageFlags::BOTTOM_OF_PIPE,
             br::PipelineStageFlags::TOP_OF_PIPE,
             true,
             &[],
             &[],
             &barriers,
-        );
+        )
     }
     fn next_back_buffer_index(&mut self) -> br::Result<u32> {
         Ok(unsafe { self.sc.GetCurrentBackBufferIndex() })

--- a/cradle/windows/src/presenter.rs
+++ b/cradle/windows/src/presenter.rs
@@ -91,11 +91,10 @@ impl peridot::PlatformPresenter for Presenter {
     fn emit_initialize_back_buffer_commands<
         'r,
         CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
-        Device: br::Device + ?Sized,
     >(
         &self,
-        recorder: br::CmdRecord<'r, CB, Device>,
-    ) -> br::CmdRecord<'r, CB, Device> {
+        recorder: br::CmdRecord<'r, CB, peridot::DeviceObject>,
+    ) -> br::CmdRecord<'r, CB, peridot::DeviceObject> {
         self.sc.emit_initialize_back_buffer_commands(recorder)
     }
     fn next_back_buffer_index(&mut self) -> br::Result<u32> {
@@ -512,11 +511,10 @@ impl peridot::PlatformPresenter for Presenter {
     fn emit_initialize_back_buffer_commands<
         'r,
         CB: br::CommandBuffer + br::VkHandleMut + ?Sized,
-        Device: br::Device + ?Sized,
     >(
         &self,
-        recorder: br::CmdRecord<'r, CB, Device>,
-    ) -> br::CmdRecord<'r, CB, Device> {
+        recorder: br::CmdRecord<'r, CB, peridot::DeviceObject>,
+    ) -> br::CmdRecord<'r, CB, peridot::DeviceObject> {
         let barriers = self
             .back_buffers
             .iter()

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -40,7 +40,7 @@ pub struct Game<PL: peridot::NativeLinker> {
         Vec<br::DescriptorSet>,
     ),
     _sampler: br::SamplerObject<peridot::DeviceObject>,
-    color_renders: Box<dyn GraphicsCommand>,
+    color_renders: Box<dyn GraphicsCommand<peridot::DeviceObject>>,
     mutable_uniform_buffer: RangedBuffer<peridot_memory_manager::Buffer>,
     _uniform_buffer: RangedBuffer<peridot_memory_manager::Buffer>,
     _image_view: br::ImageViewObject<peridot_memory_manager::Image>,
@@ -149,12 +149,10 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
         let image = memory_manager
             .allocate_device_local_image(
                 e.graphics(),
-                br::ImageDesc::new(
-                    image_data.0.size,
-                    image_data.0.format as _,
-                    br::ImageUsageFlags::SAMPLED | br::ImageUsageFlags::TRANSFER_DEST,
-                    br::ImageLayout::Preinitialized,
-                ),
+                br::ImageDesc::new(image_data.0.size, image_data.0.format as _)
+                    .sampled()
+                    .transfer_dest()
+                    .init_layout(br::ImageLayout::Preinitialized),
             )
             .expect("Failed to allocate main image");
         let mut image_data_stg_buffer = memory_manager
@@ -224,9 +222,9 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
                     );
                 let copies = (init_vertex, init_uniform, init_tex);
 
-                copies
+                let _ = copies
                     .between(in_barriers, out_barriers)
-                    .execute(&mut r.as_dyn_ref());
+                    .execute(r.as_dyn_ref());
                 r
             })
             .expect("Failed to submit pre-configure commands");
@@ -396,7 +394,7 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
             (&color_renders)
                 .between(begin_main_rp, EndRenderPass)
                 .execute_and_finish(unsafe {
-                    cb.begin()
+                    cb.begin(e.graphics_device())
                         .expect("Failed to begin command recording")
                         .as_dyn_ref()
                 })
@@ -463,7 +461,7 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
                 .as_ref()
                 .between(begin_main_rp, EndRenderPass)
                 .execute_and_finish(unsafe {
-                    cb.begin()
+                    cb.begin(e.graphics_device())
                         .expect("Failed to begin command recording")
                         .as_dyn_ref()
                 })

--- a/examples/tapfx/src/lib.rs
+++ b/examples/tapfx/src/lib.rs
@@ -42,7 +42,7 @@ fn init_controls(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
 pub struct Game<NL: peridot::NativeLinker> {
     renderpass: br::RenderPassObject<peridot::DeviceObject>,
     framebuffers: Vec<br::FramebufferObject<'static, peridot::DeviceObject>>,
-    color_renders: Box<dyn GraphicsCommand>,
+    color_renders: Box<dyn GraphicsCommand<peridot::DeviceObject>>,
     _smp: br::SamplerObject<peridot::DeviceObject>,
     _dsl: br::DescriptorSetLayoutObject<peridot::DeviceObject>,
     _dsl2: br::DescriptorSetLayoutObject<peridot::DeviceObject>,
@@ -162,12 +162,10 @@ impl<NL: peridot::NativeLinker> peridot::EngineEvents<NL> for Game<NL> {
         let main_image = memory_manager
             .allocate_device_local_image(
                 e.graphics(),
-                br::ImageDesc::new(
-                    main_image_data.0.size,
-                    main_image_data.0.format as _,
-                    br::ImageUsageFlags::SAMPLED | br::ImageUsageFlags::TRANSFER_DEST,
-                    br::ImageLayout::Preinitialized,
-                ),
+                br::ImageDesc::new(main_image_data.0.size, main_image_data.0.format as _)
+                    .sampled()
+                    .transfer_dest()
+                    .init_layout(br::ImageLayout::Preinitialized),
             )
             .expect("Failed to allocate main image");
 
@@ -315,7 +313,7 @@ impl<NL: peridot::NativeLinker> peridot::EngineEvents<NL> for Game<NL> {
             copy.between(in_barriers, out_barriers)
                 .execute_and_finish(unsafe {
                     update_commands[0]
-                        .begin()
+                        .begin(e.graphics_device())
                         .expect("Failed to begin recording update commands")
                         .as_dyn_ref()
                 })
@@ -343,7 +341,7 @@ impl<NL: peridot::NativeLinker> peridot::EngineEvents<NL> for Game<NL> {
             (&color_renders)
                 .between(rp, EndRenderPass)
                 .execute_and_finish(unsafe {
-                    b.begin()
+                    b.begin(e.graphics_device())
                         .expect("Failed to begin recording main commands")
                         .as_dyn_ref()
                 })

--- a/examples/vg-sdf-renderer/src/lib.rs
+++ b/examples/vg-sdf-renderer/src/lib.rs
@@ -509,9 +509,9 @@ pub struct TwoPassStencilSDFRendererBuffers {
 impl TwoPassStencilSDFRenderer {
     pub fn commands<'s>(
         &'s self,
-        framebuffer: &'s impl br::Framebuffer,
+        framebuffer: &'s impl br::Framebuffer<ConcreteDevice = peridot::DeviceObject>,
         buffers: &'s TwoPassStencilSDFRendererBuffers,
-    ) -> impl GraphicsCommand + 's {
+    ) -> impl GraphicsCommand<peridot::DeviceObject> + 's {
         let rp = BeginRenderPass::new(&self.render_pass, framebuffer, self.render_area())
             .with_clear_values(Self::CLEAR_VALUES.into());
 
@@ -645,12 +645,8 @@ impl<NL: peridot::NativeLinker> EngineEvents<NL> for Game<NL> {
         let stencil_buffer = memory_manager
             .allocate_device_local_image(
                 e.graphics(),
-                br::ImageDesc::new(
-                    back_buffer_size.clone(),
-                    br::vk::VK_FORMAT_S8_UINT,
-                    br::ImageUsageFlags::DEPTH_STENCIL_ATTACHMENT,
-                    br::ImageLayout::Undefined,
-                ),
+                br::ImageDesc::new(back_buffer_size.clone(), br::vk::VK_FORMAT_S8_UINT)
+                    .as_depth_stencil_attachment(),
             )
             .expect("Failed to allocate stencil buffer");
         let stencil_buffer_view = SharedRef::new(
@@ -726,10 +722,10 @@ impl<NL: peridot::NativeLinker> EngineEvents<NL> for Game<NL> {
             ];
             let out_barriers = PipelineBarrier::new()
                 .with_barrier(all_buffer_out_barrier)
-                .with_barrier(stencil_buffer.barrier(
-                    br::ImageLayout::Undefined,
-                    br::ImageLayout::DepthStencilReadOnlyOpt,
-                ))
+                .with_barrier(
+                    stencil_buffer
+                        .barrier(br::ImageLayout::DepthStencilReadOnlyOpt.from_undefined()),
+                )
                 .by_region();
 
             copy.between(in_barriers, out_barriers)
@@ -822,7 +818,7 @@ impl<NL: peridot::NativeLinker> EngineEvents<NL> for Game<NL> {
                 .commands(fb, &buffers)
                 .execute_and_finish(unsafe {
                     cmd[cx]
-                        .begin()
+                        .begin(e.graphics_device())
                         .expect("Failed to begin recording commands")
                         .as_dyn_ref()
                 })
@@ -939,9 +935,8 @@ impl<NL: peridot::NativeLinker> EngineEvents<NL> for Game<NL> {
                 br::ImageDesc::new(
                     peridot::math::Vector2(new_size.0 as u32, new_size.1 as u32),
                     br::vk::VK_FORMAT_S8_UINT,
-                    br::ImageUsageFlags::DEPTH_STENCIL_ATTACHMENT,
-                    br::ImageLayout::Undefined,
-                ),
+                )
+                .as_depth_stencil_attachment(),
             )
             .expect("Failed to allocate stencil buffer");
         self.stencil_buffer_view = SharedRef::new(
@@ -1029,10 +1024,10 @@ impl<NL: peridot::NativeLinker> EngineEvents<NL> for Game<NL> {
             ];
             let out_barriers = PipelineBarrier::new()
                 .with_barrier(all_buffer_out_barrier)
-                .with_barrier(stencil_buffer.barrier(
-                    br::ImageLayout::Undefined,
-                    br::ImageLayout::DepthStencilReadOnlyOpt,
-                ))
+                .with_barrier(
+                    stencil_buffer
+                        .barrier(br::ImageLayout::DepthStencilReadOnlyOpt.from_undefined()),
+                )
                 .by_region();
 
             copy.between(in_barriers, out_barriers)
@@ -1111,7 +1106,7 @@ impl<NL: peridot::NativeLinker> EngineEvents<NL> for Game<NL> {
                 .commands(fb, &self.buffers)
                 .execute_and_finish(unsafe {
                     self.cmd[cx]
-                        .begin()
+                        .begin(e.graphics_device())
                         .expect("Failed to begin recording commands")
                         .as_dyn_ref()
                 })

--- a/examples/vg/src/lib.rs
+++ b/examples/vg/src/lib.rs
@@ -159,14 +159,10 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
         let msaa_texture = memory_manager
             .allocate_device_local_image(
                 e.graphics(),
-                br::ImageDesc::new(
-                    rt_size.clone(),
-                    e.back_buffer_format(),
-                    br::ImageUsageFlags::COLOR_ATTACHMENT
-                        | br::ImageUsageFlags::TRANSIENT_ATTACHMENT,
-                    br::ImageLayout::Undefined,
-                )
-                .sample_counts(msaa_count),
+                br::ImageDesc::new(rt_size.clone(), e.back_buffer_format())
+                    .as_color_attachment()
+                    .as_transient_attachment()
+                    .sample_counts(msaa_count),
             )
             .expect("Failed to create msaa render target");
         let msaa_texture = SharedRef::new(
@@ -223,10 +219,8 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
             let out_barrier = PipelineBarrier::new()
                 .with_barrier(all_buffer_out_barrier)
                 .with_barrier(
-                    RangedImage::single_color_plane(msaa_texture.image()).barrier(
-                        br::ImageLayout::Undefined,
-                        br::ImageLayout::ColorAttachmentOpt,
-                    ),
+                    RangedImage::single_color_plane(msaa_texture.image())
+                        .barrier(br::ImageLayout::ColorAttachmentOpt.from_undefined()),
                 );
 
             copy.between(in_barrier, out_barrier)
@@ -470,10 +464,10 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
                     br::ClearValue::color([1.0; 4]),
                 ]);
 
-            (&color_renders)
+            (&color_renders[..])
                 .between(rp, EndRenderPass)
                 .execute_and_finish(unsafe {
-                    r.begin()
+                    r.begin(e.graphics_device())
                         .expect("Failed to begin render command recording")
                         .as_dyn_ref()
                 })
@@ -525,14 +519,10 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
             .memory_manager
             .allocate_device_local_image(
                 e.graphics(),
-                br::ImageDesc::new(
-                    rt_size.clone(),
-                    e.back_buffer_format(),
-                    br::ImageUsageFlags::COLOR_ATTACHMENT
-                        | br::ImageUsageFlags::TRANSIENT_ATTACHMENT,
-                    br::ImageLayout::Undefined,
-                )
-                .sample_counts(msaa_count),
+                br::ImageDesc::new(rt_size.clone(), e.back_buffer_format())
+                    .as_color_attachment()
+                    .as_transient_attachment()
+                    .sample_counts(msaa_count),
             )
             .expect("Failed to create msaa render target");
         let msaa_texture = SharedRef::new(
@@ -544,10 +534,8 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
         );
 
         PipelineBarrier::from(
-            RangedImage::single_color_plane(msaa_texture.image()).barrier(
-                br::ImageLayout::Undefined,
-                br::ImageLayout::ColorAttachmentOpt,
-            ),
+            RangedImage::single_color_plane(msaa_texture.image())
+                .barrier(br::ImageLayout::Undefined.to(br::ImageLayout::ColorAttachmentOpt)),
         )
         .submit(e)
         .expect("Failed to initialize msaa rt");
@@ -574,9 +562,13 @@ impl<PL: peridot::NativeLinker> peridot::EngineEvents<PL> for Game<PL> {
                     br::ClearValue::color([1.0; 4]),
                 ]);
 
-            (&self.render_vgs)
+            (&self.render_vgs[..])
                 .between(rp, EndRenderPass)
-                .execute_and_finish(unsafe { r.begin().expect("Start Recording CB").as_dyn_ref() })
+                .execute_and_finish(unsafe {
+                    r.begin(e.graphics_device())
+                        .expect("Start Recording CB")
+                        .as_dyn_ref()
+                })
                 .expect("Failed to finish render commands");
         }
     }

--- a/modules/command-object/src/graphics_command.rs
+++ b/modules/command-object/src/graphics_command.rs
@@ -14,7 +14,7 @@ pub trait GraphicsCommand<Device: br::Device + ?Sized> {
 
     fn execute_and_finish(
         &self,
-        mut cb: br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+        cb: br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
     ) -> br::Result<()> {
         self.execute(cb).end()
     }

--- a/modules/command-object/src/graphics_command.rs
+++ b/modules/command-object/src/graphics_command.rs
@@ -6,48 +6,70 @@ use crate::{
     IndexedMesh, Mesh,
 };
 
-pub trait GraphicsCommand {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>);
+pub trait GraphicsCommand<Device: br::Device + ?Sized> {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>;
 
     fn execute_and_finish(
         &self,
-        mut cb: br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>,
+        mut cb: br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
     ) -> br::Result<()> {
-        self.execute(&mut cb);
-        cb.end()
+        self.execute(cb).end()
     }
 }
-impl<T: GraphicsCommand + ?Sized> GraphicsCommand for Box<T> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+impl<T: GraphicsCommand<Device> + ?Sized, Device: br::Device + ?Sized> GraphicsCommand<Device>
+    for Box<T>
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         T::execute(&*self, cb)
     }
 }
-impl<T: GraphicsCommand + ?Sized> GraphicsCommand for std::rc::Rc<T> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+impl<T: GraphicsCommand<Device> + ?Sized, Device: br::Device + ?Sized> GraphicsCommand<Device>
+    for std::rc::Rc<T>
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         T::execute(&*self, cb)
     }
 }
-impl<T: GraphicsCommand + ?Sized> GraphicsCommand for std::sync::Arc<T> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+impl<T: GraphicsCommand<Device> + ?Sized, Device: br::Device + ?Sized> GraphicsCommand<Device>
+    for std::sync::Arc<T>
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         T::execute(&*self, cb)
     }
 }
-impl<T: GraphicsCommand + ?Sized> GraphicsCommand for &'_ T {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+impl<T: GraphicsCommand<Device> + ?Sized, Device: br::Device + ?Sized> GraphicsCommand<Device>
+    for &'_ T
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         T::execute(*self, cb)
     }
 }
 
-pub trait GraphicsCommandSubmission: GraphicsCommand {
+pub trait GraphicsCommandSubmission: GraphicsCommand<peridot::DeviceObject> {
     fn submit(&self, engine: &mut peridot::Engine<impl peridot::NativeLinker>) -> br::Result<()> {
         engine.submit_commands(|mut r| {
-            self.execute(&mut r.as_dyn_ref());
+            let _ = self.execute(r.as_dyn_ref());
             r
         })
     }
 }
-impl<T: GraphicsCommand> GraphicsCommandSubmission for T {}
-pub trait GraphicsCommandCombiner: GraphicsCommand + Sized {
+impl<T: GraphicsCommand<peridot::DeviceObject>> GraphicsCommandSubmission for T {}
+pub trait GraphicsCommandCombiner: Sized {
     #[inline]
     fn then<C>(self, next: C) -> (Self, C) {
         (self, next)
@@ -64,52 +86,73 @@ pub trait GraphicsCommandCombiner: GraphicsCommand + Sized {
     }
 
     #[inline]
-    fn boxed(self) -> Box<dyn GraphicsCommand>
+    fn boxed<Device: br::Device + ?Sized>(self) -> Box<dyn GraphicsCommand<Device>>
     where
-        Self: 'static,
+        Self: GraphicsCommand<Device> + 'static,
     {
         Box::new(self) as _
     }
 }
-impl<T: GraphicsCommand + Sized> GraphicsCommandCombiner for T {}
+impl<T: Sized> GraphicsCommandCombiner for T {}
 
 /// consecutive exec
-impl<A: GraphicsCommand, B: GraphicsCommand> GraphicsCommand for (A, B) {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        self.0.execute(cb);
-        self.1.execute(cb);
-    }
-}
-/// consecutive exec
-impl<A: GraphicsCommand, B: GraphicsCommand, C: GraphicsCommand> GraphicsCommand for (A, B, C) {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        self.0.execute(cb);
-        self.1.execute(cb);
-        self.2.execute(cb);
-    }
-}
-/// consecutive exec
-impl<T: GraphicsCommand> GraphicsCommand for Vec<T> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        for r in self {
-            r.execute(cb);
-        }
-    }
-}
-impl<'x, T> GraphicsCommand for &'x [T]
-where
-    &'x T: GraphicsCommand,
+impl<A: GraphicsCommand<Device>, B: GraphicsCommand<Device>, Device: br::Device + ?Sized>
+    GraphicsCommand<Device> for (A, B)
 {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        for r in *self {
-            r.execute(cb);
-        }
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        let cb = self.0.execute(cb);
+        self.1.execute(cb)
+    }
+}
+/// consecutive exec
+impl<
+        A: GraphicsCommand<Device>,
+        B: GraphicsCommand<Device>,
+        C: GraphicsCommand<Device>,
+        Device: br::Device,
+    > GraphicsCommand<Device> for (A, B, C)
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        let cb = self.0.execute(cb);
+        let cb = self.1.execute(cb);
+        self.2.execute(cb)
+    }
+}
+/// consecutive exec
+impl<T: GraphicsCommand<Device>, Device: br::Device + ?Sized> GraphicsCommand<Device> for Vec<T> {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        (&self[..]).execute(cb)
+    }
+}
+impl<T, Device: br::Device + ?Sized> GraphicsCommand<Device> for [T]
+where
+    for<'x> &'x T: GraphicsCommand<Device>,
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        self.iter().fold(cb, |cb, r| r.execute(cb))
     }
 }
 
-impl<P: br::Pipeline, L: br::PipelineLayout> GraphicsCommand for peridot::LayoutedPipeline<P, L> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        self.bind(cb);
+impl<P: br::Pipeline, L: br::PipelineLayout, Device: br::Device + ?Sized> GraphicsCommand<Device>
+    for peridot::LayoutedPipeline<P, L>
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        self.bind(cb)
     }
 }
 
@@ -181,8 +224,11 @@ impl PipelineBarrier {
         iter.fold(self, |t, b| t.with_barrier(b))
     }
 }
-impl GraphicsCommand for PipelineBarrier {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+impl<Device: br::Device + ?Sized> GraphicsCommand<Device> for PipelineBarrier {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         // Note: src_stage_mask=0はVulkanの仕様上だめらしい
         let src_stage_mask = if self.src_stage_mask.0 == 0 {
             br::PipelineStageFlags::TOP_OF_PIPE
@@ -190,14 +236,14 @@ impl GraphicsCommand for PipelineBarrier {
             self.src_stage_mask
         };
 
-        let _ = cb.pipeline_barrier(
+        cb.pipeline_barrier(
             src_stage_mask,
             self.dst_stage_mask,
             self.by_region,
             &[],
             &self.buffer_barriers,
             &self.image_barriers,
-        );
+        )
     }
 }
 impl From<br::ImageMemoryBarrier> for PipelineBarrier {
@@ -214,7 +260,7 @@ impl<B: br::Buffer> From<BufferUsageTransitionBarrier<B>> for PipelineBarrier {
 pub struct CopyBuffer<
     S: br::VkHandle<Handle = br::vk::VkBuffer>,
     D: br::VkHandle<Handle = br::vk::VkBuffer>,
->(S, D, Vec<br::vk::VkBufferCopy>);
+>(S, D, Vec<br::BufferCopy>);
 impl<S: br::VkHandle<Handle = br::vk::VkBuffer>, D: br::VkHandle<Handle = br::vk::VkBuffer>>
     CopyBuffer<S, D>
 {
@@ -222,18 +268,21 @@ impl<S: br::VkHandle<Handle = br::vk::VkBuffer>, D: br::VkHandle<Handle = br::vk
         Self(source, dest, Vec::new())
     }
 
-    pub fn with_ranges(mut self, ranges: impl IntoIterator<Item = br::vk::VkBufferCopy>) -> Self {
+    pub fn with_ranges(mut self, ranges: impl IntoIterator<Item = br::BufferCopy>) -> Self {
         self.2.extend(ranges);
 
         self
     }
 
     pub fn with_range(mut self, src_offset: u64, dest_offset: u64, size: usize) -> Self {
-        self.2.push(br::vk::VkBufferCopy {
-            srcOffset: src_offset,
-            dstOffset: dest_offset,
-            size: size as _,
-        });
+        self.2.push(
+            br::vk::VkBufferCopy {
+                srcOffset: src_offset,
+                dstOffset: dest_offset,
+                size: size as _,
+            }
+            .into(),
+        );
         self
     }
 
@@ -249,11 +298,17 @@ impl<S: br::VkHandle<Handle = br::vk::VkBuffer>, D: br::VkHandle<Handle = br::vk
         self.with_mirroring(offset, std::mem::size_of::<T>())
     }
 }
-impl<S: br::VkHandle<Handle = br::vk::VkBuffer>, D: br::VkHandle<Handle = br::vk::VkBuffer>>
-    GraphicsCommand for CopyBuffer<S, D>
+impl<
+        S: br::VkHandle<Handle = br::vk::VkBuffer>,
+        D: br::VkHandle<Handle = br::vk::VkBuffer>,
+        Device: br::Device + ?Sized,
+    > GraphicsCommand<Device> for CopyBuffer<S, D>
 {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb.copy_buffer(&self.0, &self.1, &self.2);
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.copy_buffer(&self.0, &self.1, &self.2)
     }
 }
 
@@ -295,14 +350,22 @@ impl<S: br::Buffer, D: br::Image> CopyBufferToImage<S, D> {
         self
     }
 }
-impl<S: br::Buffer, D: br::Image> GraphicsCommand for CopyBufferToImage<S, D> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb.copy_buffer_to_image(
+impl<
+        S: br::Buffer<ConcreteDevice = Device>,
+        D: br::Image<ConcreteDevice = Device>,
+        Device: br::Device + ?Sized,
+    > GraphicsCommand<Device> for CopyBufferToImage<S, D>
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.copy_buffer_to_image(
             &self.source,
             &self.dest,
             self.dest_image_layout,
             &self.regions,
-        );
+        )
     }
 }
 
@@ -358,15 +421,23 @@ where
         )
     }
 }
-impl<R: br::RenderPass, F: br::Framebuffer> GraphicsCommand for BeginRenderPass<R, F> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb.begin_render_pass(
+impl<
+        R: br::RenderPass<ConcreteDevice = Device>,
+        F: br::Framebuffer<ConcreteDevice = Device>,
+        Device: br::Device + ?Sized,
+    > GraphicsCommand<Device> for BeginRenderPass<R, F>
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.begin_render_pass(
             &self.render_pass,
             &self.framebuffer,
             self.rect.clone(),
             &self.clear_values,
             self.inline_commands,
-        );
+        )
     }
 }
 
@@ -375,16 +446,22 @@ impl NextSubpass {
     pub const WITH_INLINE_COMMANDS: Self = Self(true);
     pub const WITH_COMMAND_BUFFER_EXECUTIONS: Self = Self(false);
 }
-impl GraphicsCommand for NextSubpass {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb.next_subpass(self.0);
+impl<Device: br::Device + ?Sized> GraphicsCommand<Device> for NextSubpass {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.next_subpass(self.0)
     }
 }
 
 pub struct EndRenderPass;
-impl GraphicsCommand for EndRenderPass {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb.end_render_pass();
+impl<Device: br::Device + ?Sized> GraphicsCommand<Device> for EndRenderPass {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.end_render_pass()
     }
 }
 
@@ -447,17 +524,21 @@ where
         }
     }
 }
-impl<Sets, DynamicOffsets> GraphicsCommand for BindGraphicsDescriptorSets<Sets, DynamicOffsets>
+impl<Sets, DynamicOffsets, Device: br::Device + ?Sized> GraphicsCommand<Device>
+    for BindGraphicsDescriptorSets<Sets, DynamicOffsets>
 where
     Sets: AsRef<[br::vk::VkDescriptorSet]>,
     DynamicOffsets: AsRef<[u32]>,
 {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb.bind_graphics_descriptor_sets(
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.bind_graphics_descriptor_sets(
             self.from,
             self.sets.as_ref(),
             self.dynamic_offsets.as_ref(),
-        );
+        )
     }
 }
 
@@ -483,31 +564,41 @@ impl<T> PushConstant<T> {
         }
     }
 }
-impl<T> GraphicsCommand for PushConstant<T> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+impl<T, Device: br::Device + ?Sized> GraphicsCommand<Device> for PushConstant<T> {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         if (self.shader_stage.0 & br::vk::VK_SHADER_STAGE_COMPUTE_BIT) != 0 {
             // assumes compute pipeline
-            let _ = cb.push_compute_constant(self.shader_stage, self.offset, &self.value);
+            cb.push_compute_constant(self.shader_stage, self.offset, &self.value)
         } else {
-            let _ = cb.push_graphics_constant(self.shader_stage, self.offset, &self.value);
+            cb.push_graphics_constant(self.shader_stage, self.offset, &self.value)
         }
     }
 }
 
 pub struct ViewportWithScissorRect(pub br::vk::VkViewport, pub br::vk::VkRect2D);
-impl GraphicsCommand for ViewportWithScissorRect {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb
-            .set_viewport(0, &[self.0.clone()])
-            .set_scissor(0, &[self.1.clone()]);
+impl<Device: br::Device + ?Sized> GraphicsCommand<Device> for ViewportWithScissorRect {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.set_viewport(0, &[self.0.clone()])
+            .set_scissor(0, &[self.1.clone()])
     }
 }
-impl<const N: usize> GraphicsCommand for [ViewportWithScissorRect; N] {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+impl<const N: usize, Device: br::Device + ?Sized> GraphicsCommand<Device>
+    for [ViewportWithScissorRect; N]
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         let (viewports, scissors): (Vec<_>, Vec<_>) =
             self.iter().map(|a| (a.0.clone(), a.1.clone())).unzip();
 
-        let _ = cb.set_viewport(0, &viewports).set_scissor(0, &scissors);
+        cb.set_viewport(0, &viewports).set_scissor(0, &scissors)
     }
 }
 
@@ -558,17 +649,22 @@ impl<const N: usize> From<[ViewportWithScissorRect; N]> for ViewportScissorRects
         }
     }
 }
-impl GraphicsCommand for ViewportScissorRects {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb
-            .set_viewport(0, &self.viewports)
-            .set_scissor(0, &self.scissors);
+impl<Device: br::Device + ?Sized> GraphicsCommand<Device> for ViewportScissorRects {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.set_viewport(0, &self.viewports)
+            .set_scissor(0, &self.scissors)
     }
 }
 
 pub struct PreConfigureDraw<M: Mesh>(pub M);
-impl<M: Mesh> GraphicsCommand for PreConfigureDraw<M> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+impl<M: Mesh, Device: br::Device + ?Sized> GraphicsCommand<Device> for PreConfigureDraw<M> {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         let vertex_buffers = self
             .0
             .vertex_buffers()
@@ -576,13 +672,18 @@ impl<M: Mesh> GraphicsCommand for PreConfigureDraw<M> {
             .map(|rb| (&rb.0, rb.1.start as usize))
             .collect::<Vec<_>>();
 
-        let _ = cb.bind_vertex_buffers(0, &vertex_buffers);
+        cb.bind_vertex_buffers(0, &vertex_buffers)
     }
 }
 
 pub struct PreConfigureDrawIndexed<M: IndexedMesh>(pub M);
-impl<M: IndexedMesh> GraphicsCommand for PreConfigureDrawIndexed<M> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+impl<M: IndexedMesh, Device: br::Device + ?Sized> GraphicsCommand<Device>
+    for PreConfigureDrawIndexed<M>
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         let vertex_buffers = self
             .0
             .vertex_buffers()
@@ -590,20 +691,22 @@ impl<M: IndexedMesh> GraphicsCommand for PreConfigureDrawIndexed<M> {
             .map(|rb| (&rb.0, rb.1.start as usize))
             .collect::<Vec<_>>();
 
-        let _ = cb
-            .bind_vertex_buffers(0, &vertex_buffers)
+        cb.bind_vertex_buffers(0, &vertex_buffers)
             .bind_index_buffer(
                 &self.0.index_buffer().inner_ref(),
                 self.0.index_buffer().offset() as _,
                 self.0.index_type(),
-            );
+            )
     }
 }
 
 pub struct SimpleDraw(pub u32, pub u32, pub u32, pub u32);
-impl GraphicsCommand for SimpleDraw {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb.draw(self.0, self.1, self.2, self.3);
+impl<Device: br::Device + ?Sized> GraphicsCommand<Device> for SimpleDraw {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.draw(self.0, self.1, self.2, self.3)
     }
 }
 
@@ -639,15 +742,18 @@ impl SimpleDrawIndexed {
         }
     }
 }
-impl GraphicsCommand for SimpleDrawIndexed {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = cb.draw_indexed(
+impl<Device: br::Device + ?Sized> GraphicsCommand<Device> for SimpleDrawIndexed {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        cb.draw_indexed(
             self.index_count,
             self.instance_count,
             self.first_index,
             self.vertex_offset,
             self.first_instance,
-        );
+        )
     }
 }
 
@@ -657,11 +763,14 @@ pub struct DrawMesh<M: Mesh> {
     pub vertex_start: u32,
     pub instance_start: u32,
 }
-impl<M: Mesh> GraphicsCommand for DrawMesh<M>
+impl<M: Mesh, Device: br::Device + ?Sized> GraphicsCommand<Device> for DrawMesh<M>
 where
     for<'r> &'r M: Mesh,
 {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         let vertex_count = self.mesh.vertex_count();
 
         (
@@ -673,7 +782,7 @@ where
                 self.instance_start,
             ),
         )
-            .execute(cb);
+            .execute(cb)
     }
 }
 
@@ -684,11 +793,14 @@ pub struct DrawIndexedMesh<M: IndexedMesh> {
     pub index_offset: i32,
     pub instance_start: u32,
 }
-impl<M: IndexedMesh> GraphicsCommand for DrawIndexedMesh<M>
+impl<M: IndexedMesh, Device: br::Device + ?Sized> GraphicsCommand<Device> for DrawIndexedMesh<M>
 where
     for<'r> &'r M: IndexedMesh,
 {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
         (
             PreConfigureDrawIndexed(&self.mesh),
             SimpleDrawIndexed {
@@ -699,23 +811,40 @@ where
                 first_instance: self.instance_start,
             },
         )
-            .execute(cb);
+            .execute(cb)
     }
 }
 
-impl GraphicsCommand for &'_ [br::vk::VkCommandBuffer] {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = unsafe { cb.execute_commands(self) };
+#[repr(transparent)]
+pub struct CommandBuffers(pub Vec<VkCommandBuffer>);
+
+#[repr(transparent)]
+pub struct CommandBuffersRef<'s>(pub &'s [VkCommandBuffer]);
+
+impl<Device: br::Device + ?Sized> GraphicsCommand<Device> for CommandBuffersRef<'_> {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        unsafe { cb.execute_commands(self.0) }
     }
 }
-impl<const N: usize> GraphicsCommand for [br::vk::VkCommandBuffer; N] {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = unsafe { cb.execute_commands(self) };
+impl<const N: usize, Device: br::Device + ?Sized> GraphicsCommand<Device>
+    for [br::vk::VkCommandBuffer; N]
+{
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        unsafe { cb.execute_commands(self) }
     }
 }
-impl GraphicsCommand for Vec<br::vk::VkCommandBuffer> {
-    fn execute(&self, cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = VkCommandBuffer>>) {
-        let _ = unsafe { cb.execute_commands(&self[..]) };
+impl<Device: br::Device + ?Sized> GraphicsCommand<Device> for CommandBuffers {
+    fn execute<'r>(
+        &self,
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = VkCommandBuffer>, Device> {
+        unsafe { cb.execute_commands(&self.0[..]) }
     }
 }
 

--- a/modules/command-object/src/lib.rs
+++ b/modules/command-object/src/lib.rs
@@ -158,13 +158,18 @@ impl<B: br::Buffer> PipelineBarrierEntry for BufferUsageTransitionBarrier<B> {
         barrier.buffer_barriers.reserve(count);
     }
 }
-impl<const N: usize, B: br::Buffer + Clone> GraphicsCommand
+impl<const N: usize, B: br::Buffer + Clone> GraphicsCommand<B::ConcreteDevice>
     for [BufferUsageTransitionBarrier<B>; N]
 {
-    fn execute(
+    fn execute<'r>(
         &self,
-        cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = br::vk::VkCommandBuffer>>,
-    ) {
+        cb: br::CmdRecord<
+            'r,
+            dyn br::VkHandleMut<Handle = br::vk::VkCommandBuffer>,
+            B::ConcreteDevice,
+        >,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = br::vk::VkCommandBuffer>, B::ConcreteDevice>
+    {
         PipelineBarrier::new()
             .with_barriers(self.iter().cloned())
             .execute(cb)

--- a/modules/command-object/src/ranged_resources.rs
+++ b/modules/command-object/src/ranged_resources.rs
@@ -95,7 +95,10 @@ impl<B: br::Buffer> RangedBuffer<B> {
     /// generates copying command from self to dest.
     ///
     /// both buffer length must be equal
-    pub fn copy_to(self, dest: RangedBuffer<impl br::Buffer>) -> impl GraphicsCommand {
+    pub fn copy_to(
+        self,
+        dest: RangedBuffer<impl br::Buffer<ConcreteDevice = B::ConcreteDevice>>,
+    ) -> impl GraphicsCommand<B::ConcreteDevice> {
         assert_eq!(self.byte_length(), dest.byte_length());
 
         let (s, d, len) = (self.offset(), dest.offset(), self.byte_length());
@@ -105,14 +108,20 @@ impl<B: br::Buffer> RangedBuffer<B> {
     /// generates copying command from src to self. (reversing copy_
     ///
     /// both buffer length must be equal
-    pub fn copy_from(self, src: RangedBuffer<impl br::Buffer>) -> impl GraphicsCommand {
+    pub fn copy_from(
+        self,
+        src: RangedBuffer<impl br::Buffer<ConcreteDevice = B::ConcreteDevice>>,
+    ) -> impl GraphicsCommand<B::ConcreteDevice> {
         src.copy_to(self)
     }
 
     /// generates mirroring command from self to dest.
     ///
     /// both buffer length must be equal.
-    pub fn mirror_to(self, dest: RangedBuffer<impl br::Buffer>) -> impl GraphicsCommand {
+    pub fn mirror_to(
+        self,
+        dest: RangedBuffer<impl br::Buffer<ConcreteDevice = B::ConcreteDevice>>,
+    ) -> impl GraphicsCommand<B::ConcreteDevice> {
         assert_eq!(self.byte_length(), dest.byte_length());
 
         let len = self.byte_length();
@@ -122,7 +131,10 @@ impl<B: br::Buffer> RangedBuffer<B> {
     /// generates mirroring command from src to self. (reversing mirror_to arguments)
     ///
     /// both buffer length must be equal.
-    pub fn mirror_from(self, src: RangedBuffer<impl br::Buffer>) -> impl GraphicsCommand {
+    pub fn mirror_from(
+        self,
+        src: RangedBuffer<impl br::Buffer<ConcreteDevice = B::ConcreteDevice>>,
+    ) -> impl GraphicsCommand<B::ConcreteDevice> {
         src.mirror_to(self)
     }
 
@@ -131,8 +143,8 @@ impl<B: br::Buffer> RangedBuffer<B> {
     /// both buffer length must be equal.
     pub fn byref_mirror_to<'s>(
         &'s self,
-        dest: &'s RangedBuffer<impl br::Buffer>,
-    ) -> impl GraphicsCommand + 's {
+        dest: &'s RangedBuffer<impl br::Buffer<ConcreteDevice = B::ConcreteDevice>>,
+    ) -> impl GraphicsCommand<B::ConcreteDevice> + 's {
         assert_eq!(self.byte_length(), dest.byte_length());
 
         CopyBuffer::new(&self.0, &dest.0).with_mirroring(0, self.byte_length() as _)
@@ -143,8 +155,8 @@ impl<B: br::Buffer> RangedBuffer<B> {
     /// both buffer length must be equal.
     pub fn byref_mirror_from<'s>(
         &'s self,
-        src: &'s RangedBuffer<impl br::Buffer>,
-    ) -> impl GraphicsCommand + 's {
+        src: &'s RangedBuffer<impl br::Buffer<ConcreteDevice = B::ConcreteDevice>>,
+    ) -> impl GraphicsCommand<B::ConcreteDevice> + 's {
         src.byref_mirror_to(self)
     }
 }
@@ -243,12 +255,8 @@ impl<R: br::Image> RangedImage<R> {
         Self(resource.subresource_range(br::AspectMask::STENCIL, 0..1, 0..1))
     }
 
-    pub fn barrier(
-        &self,
-        from_layout: br::ImageLayout,
-        to_layout: br::ImageLayout,
-    ) -> br::ImageMemoryBarrier {
-        self.0.make_ref().memory_barrier(from_layout, to_layout)
+    pub fn barrier(&self, trans: br::LayoutTransition) -> br::ImageMemoryBarrier {
+        self.0.make_ref().memory_barrier(trans)
     }
 
     pub fn barrier3(
@@ -258,8 +266,8 @@ impl<R: br::Image> RangedImage<R> {
         last_layout: br::ImageLayout,
     ) -> [br::ImageMemoryBarrier; 2] {
         [
-            self.barrier(first_layout, intermedial_layout),
-            self.barrier(intermedial_layout, last_layout),
+            self.barrier(first_layout.to(intermedial_layout)),
+            self.barrier(intermedial_layout.to(last_layout)),
         ]
     }
 }

--- a/modules/math/src/linarg.rs
+++ b/modules/math/src/linarg.rs
@@ -413,6 +413,18 @@ impl<T: One + Zero> Matrix4<T> {
     }
 }
 
+// TRS(Translate-Rotate-Scale) constructor //
+impl<T> Matrix4<T> {
+    pub fn trs(translate: Vector3<T>, rotate: Quaternion<T>, scale: Vector3<T>) -> Self
+    where
+        T: One + Zero + Mul<T, Output = T> + Sub<T, Output = T> + Add<T, Output = T> + Copy,
+    {
+        Matrix4::translation(translate)
+            * Matrix4::from(rotate)
+            * Matrix4::scale(scale.with_w(T::ONE))
+    }
+}
+
 fn dotproduct2<T: Mul + Copy>(a: &[T; 2], b: &[T; 2]) -> <T as Mul>::Output
 where
     <T as Mul>::Output: Add<Output = <T as Mul>::Output>,

--- a/modules/memory-manager/src/lib.rs
+++ b/modules/memory-manager/src/lib.rs
@@ -893,7 +893,7 @@ impl MemoryManager {
         let mut bp = peridot::BufferPrealloc::new(e);
         let mut offsets = [0u64; N];
         for (o, c) in offsets.iter_mut().zip(contents.iter()) {
-            *o = bp.add(c);
+            *o = bp.add(*c);
         }
         let obj = self.allocate_upload_buffer(e, bp.build_desc_custom_usage(usage))?;
 

--- a/modules/memory-manager/src/lib.rs
+++ b/modules/memory-manager/src/lib.rs
@@ -597,6 +597,22 @@ impl MemoryManager {
         Ok((obj, offsets))
     }
 
+    pub fn allocate_device_local_buffer_with_content_array<const N: usize>(
+        &mut self,
+        e: &peridot::Graphics,
+        contents: &[peridot::BufferContent; N],
+        add_usage: br::BufferUsage,
+    ) -> br::Result<(Buffer, [u64; N])> {
+        let mut bp = peridot::BufferPrealloc::new(e);
+        let mut offsets = [0u64; N];
+        for (o, c) in offsets.iter_mut().zip(contents.iter()) {
+            *o = bp.add(*c);
+        }
+        let obj = self.allocate_device_local_buffer(e, bp.build_desc().and_usage(add_usage))?;
+
+        Ok((obj, offsets))
+    }
+
     fn find_uploadable_memory_type(&self, index_mask: u32) -> Option<&MemoryType> {
         // prefer host coherent(for less operations)
         let mut target_types = self
@@ -863,6 +879,22 @@ impl MemoryManager {
     ) -> br::Result<(Buffer, Vec<u64>)> {
         let mut bp = peridot::BufferPrealloc::new(e);
         let offsets = contents.into_iter().map(|c| bp.add(c)).collect::<Vec<_>>();
+        let obj = self.allocate_upload_buffer(e, bp.build_desc_custom_usage(usage))?;
+
+        Ok((obj, offsets))
+    }
+
+    pub fn allocate_upload_buffer_with_content_array<const N: usize>(
+        &mut self,
+        e: &peridot::Graphics,
+        contents: &[peridot::BufferContent; N],
+        usage: br::BufferUsage,
+    ) -> br::Result<(Buffer, [u64; N])> {
+        let mut bp = peridot::BufferPrealloc::new(e);
+        let mut offsets = [0u64; N];
+        for (o, c) in offsets.iter_mut().zip(contents.iter()) {
+            *o = bp.add(c);
+        }
         let obj = self.allocate_upload_buffer(e, bp.build_desc_custom_usage(usage))?;
 
         Ok((obj, offsets))

--- a/modules/vg/src/rendering.rs
+++ b/modules/vg/src/rendering.rs
@@ -10,8 +10,8 @@ use peridot::{
     NativeLinker,
 };
 use peridot_command_object::{
-    DescriptorSets, GraphicsCommand, GraphicsCommandCombiner, PreConfigureDrawIndexed,
-    PushConstant, RangedBuffer, SimpleDrawIndexed, StandardIndexedMesh,
+    DescriptorSets, GraphicsCommand, GraphicsCommandCombiner, PushConstant, RangedBuffer,
+    SimpleDrawIndexed, StandardIndexedMesh,
 };
 use std::mem::size_of;
 use std::ops::Range;

--- a/modules/vg/src/rendering.rs
+++ b/modules/vg/src/rendering.rs
@@ -223,48 +223,46 @@ impl Context {
 impl<'e, Device: br::Device + 'e> DefaultRenderCommands<'e, Device> for RendererParams {
     type Extras = RendererExternalInstances<'e, Device>;
 
-    fn default_render_commands<NL: NativeLinker>(
+    fn default_render_commands<
+        'r,
+        NL: NativeLinker,
+        CB: br::VkHandleMut<Handle = br::vk::VkCommandBuffer> + ?Sized,
+    >(
         &self,
         e: &Engine<NL>,
-        cmd: &mut br::CmdRecord<impl br::VkHandleMut<Handle = br::vk::VkCommandBuffer> + ?Sized>,
+        cmd: br::CmdRecord<'r, CB, Device>,
         buffer: &(impl br::Buffer<ConcreteDevice = Device> + ?Sized),
         extras: Self::Extras,
-    ) {
+    ) -> br::CmdRecord<'r, CB, Device> {
         let renderscale = extras.target_pixels.clone() * e.rendering_precision().recip();
-        extras.interior_pipeline.bind(cmd);
-        let _ = cmd
+        let cmd = extras
+            .interior_pipeline
+            .bind(cmd)
             .push_graphics_constant(br::ShaderStage::VERTEX, 0, &renderscale)
             .push_graphics_constant(br::ShaderStage::VERTEX, 4 * 3, &0u32)
-            .bind_graphics_descriptor_sets(
-                0,
-                &[extras.transform_buffer_descriptor_set.into()],
-                &[],
-            );
-
-        let _ = cmd
+            .bind_graphics_descriptor_sets(0, &[extras.transform_buffer_descriptor_set.into()], &[])
             .bind_vertex_buffers(0, &[(buffer, self.buffer_offsets.interior_positions)])
             .bind_index_buffer(
                 buffer,
                 self.buffer_offsets.interior_indices,
                 br::IndexType::U32,
-            );
-        for (n, ir) in self
-            .render_info
-            .interior_index_range_per_mesh
-            .iter()
-            .enumerate()
-        {
-            // skip if there is no indices
-            if ir.end == ir.start {
-                continue;
-            }
+            )
+            .inject(|r| {
+                self.render_info
+                    .interior_index_range_per_mesh
+                    .iter()
+                    .enumerate()
+                    // skip if there is no indices
+                    .filter(|(_, ir)| ir.end != ir.start)
+                    .fold(r, |r, (n, ir)| {
+                        r.push_graphics_constant(br::ShaderStage::VERTEX, 4 * 2, &(n as u32))
+                            .draw_indexed((ir.end - ir.start) as _, 1, ir.start as _, 0, 0)
+                    })
+            });
 
-            let _ = cmd
-                .push_graphics_constant(br::ShaderStage::VERTEX, 4 * 2, &(n as u32))
-                .draw_indexed((ir.end - ir.start) as _, 1, ir.start as _, 0, 0);
-        }
-        extras.curve_pipeline.bind(cmd);
-        let _ = cmd
+        extras
+            .curve_pipeline
+            .bind(cmd)
             .bind_vertex_buffers(
                 0,
                 &[
@@ -276,21 +274,18 @@ impl<'e, Device: br::Device + 'e> DefaultRenderCommands<'e, Device> for Renderer
                 buffer,
                 self.buffer_offsets.curve_indices,
                 br::IndexType::U32,
-            );
-        for (n, ir) in self
-            .render_info
-            .curve_index_range_per_mesh
-            .iter()
-            .enumerate()
-        {
-            if ir.end == ir.start {
-                continue;
-            }
-
-            let _ = cmd
-                .push_graphics_constant(br::ShaderStage::VERTEX, 4 * 2, &(n as u32))
-                .draw_indexed(ir.end - ir.start, 1, ir.start, 0, 0);
-        }
+            )
+            .inject(|r| {
+                self.render_info
+                    .curve_index_range_per_mesh
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, ir)| ir.end != ir.start)
+                    .fold(r, |r, (n, ir)| {
+                        r.push_graphics_constant(br::ShaderStage::VERTEX, 4 * 2, &(n as u32))
+                            .draw_indexed(ir.end - ir.start, 1, ir.start, 0, 0)
+                    })
+            })
     }
 }
 
@@ -314,13 +309,13 @@ impl<Device: br::Device, Buffer: br::Buffer<ConcreteDevice = Device>> RenderVG<D
         core::mem::replace(&mut self.buffer, new_buffer)
     }
 }
-impl<Device: br::Device, Buffer: br::Buffer<ConcreteDevice = Device>> GraphicsCommand
+impl<Device: br::Device, Buffer: br::Buffer<ConcreteDevice = Device>> GraphicsCommand<Device>
     for RenderVG<Device, Buffer>
 {
-    fn execute(
+    fn execute<'r>(
         &self,
-        cb: &mut br::CmdRecord<'_, dyn br::VkHandleMut<Handle = br::vk::VkCommandBuffer>>,
-    ) {
+        cb: br::CmdRecord<'r, dyn br::VkHandleMut<Handle = br::vk::VkCommandBuffer>, Device>,
+    ) -> br::CmdRecord<'r, dyn br::VkHandleMut<Handle = br::vk::VkCommandBuffer>, Device> {
         let render_scale = self.target_pixels.clone() * self.rendering_precision.recip();
 
         let common_configs = (
@@ -402,6 +397,6 @@ impl<Device: br::Device, Buffer: br::Buffer<ConcreteDevice = Device>> GraphicsCo
             interior_render.after_of((&self.interior_pipeline).then(common_configs)),
             curve_render.after_of(&self.curve_pipeline),
         )
-            .execute(cb);
+            .execute(cb)
     }
 }


### PR DESCRIPTION
* Matrix4::TRS(Translation-Rotation-Scale行列を一括で作成してくれるもの)
* Memory Managerに固定長配列系のメソッドを追加
* 他bedrockのアップデートで壊れたものを修正