### PR TITLE
シングルスレッドランナー

### DIFF
--- a/base/src/input.rs
+++ b/base/src/input.rs
@@ -209,14 +209,14 @@ struct FrameData {
 }
 
 pub struct InputProcessSharedState {
-    nativelink: Option<Box<dyn NativeInput + Sync + Send>>,
+    nativelink: Option<Box<dyn NativeInput>>,
     collected: AsyncCollectedData,
     frame: FrameData,
     input_map: InputMaps,
 }
 impl InputProcessSharedState {
     #[inline]
-    pub fn set_nativelink(&mut self, n: Box<dyn NativeInput + Sync + Send>) {
+    pub fn set_nativelink(&mut self, n: Box<dyn NativeInput>) {
         self.nativelink = Some(n);
     }
 
@@ -358,7 +358,7 @@ impl InputProcess {
     }
 
     #[inline]
-    pub fn set_nativelink(&self, n: Box<dyn NativeInput + Sync + Send>) {
+    pub fn set_nativelink(&self, n: Box<dyn NativeInput>) {
         self.state_write_lock().set_nativelink(n);
     }
 

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -229,11 +229,11 @@ impl EngineEventReceiver {
     }
 }
 
-pub struct WaitForEventFuture<'e> {
+pub struct NextEventFuture<'e> {
     queue: &'e RefCell<VecDeque<Event>>,
     queue_waker: &'e RefCell<Vec<core::task::Waker>>,
 }
-impl core::future::Future for WaitForEventFuture<'_> {
+impl core::future::Future for NextEventFuture<'_> {
     type Output = Event;
 
     #[inline]
@@ -270,8 +270,8 @@ impl EventQueue {
     }
 
     #[inline(always)]
-    pub fn wait_for_event<'q>(&'q self) -> impl core::future::Future<Output = Event> + 'q {
-        WaitForEventFuture {
+    pub fn next_event<'q>(&'q self) -> impl core::future::Future<Output = Event> + 'q {
+        NextEventFuture {
             queue: &self.queue,
             queue_waker: &self.queue_waker,
         }
@@ -344,8 +344,8 @@ impl<'q, NL: NativeLinker> Engine<'q, NL> {
     }
 
     #[inline(always)]
-    pub fn wait_for_event2(&self) -> impl core::future::Future<Output = Event> + 'q {
-        self.shared_event_queue.wait_for_event()
+    pub fn next_event(&self) -> impl core::future::Future<Output = Event> + 'q {
+        self.shared_event_queue.next_event()
     }
 
     pub async fn quit(&self) {

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -10,6 +10,7 @@ use br::Status;
 use parking_lot::RwLock;
 use std::borrow::Cow;
 use std::cell::{Ref, RefCell};
+use std::collections::VecDeque;
 use std::ffi::CStr;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -228,7 +229,56 @@ impl EngineEventReceiver {
     }
 }
 
-pub struct Engine<NL: NativeLinker> {
+pub struct WaitForEventFuture<'e> {
+    queue: &'e RefCell<VecDeque<Event>>,
+    queue_waker: &'e RefCell<Vec<core::task::Waker>>,
+}
+impl core::future::Future for WaitForEventFuture<'_> {
+    type Output = Event;
+
+    #[inline]
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        if let Some(e) = self.queue.borrow_mut().pop_front() {
+            core::task::Poll::Ready(e)
+        } else {
+            self.queue_waker.borrow_mut().push(cx.waker().clone());
+            core::task::Poll::Pending
+        }
+    }
+}
+
+pub struct EventQueue {
+    queue: RefCell<VecDeque<Event>>,
+    queue_waker: RefCell<Vec<core::task::Waker>>,
+}
+impl EventQueue {
+    pub fn new() -> Self {
+        Self {
+            queue: RefCell::new(VecDeque::new()),
+            queue_waker: RefCell::new(Vec::new()),
+        }
+    }
+
+    pub fn enqueue(&self, event: Event) {
+        self.queue.borrow_mut().push_back(event);
+        for w in core::mem::replace(&mut *self.queue_waker.borrow_mut(), Vec::new()) {
+            w.wake();
+        }
+    }
+
+    #[inline(always)]
+    pub fn wait_for_event<'q>(&'q self) -> impl core::future::Future<Output = Event> + 'q {
+        WaitForEventFuture {
+            queue: &self.queue,
+            queue_waker: &self.queue_waker,
+        }
+    }
+}
+
+pub struct Engine<'q, NL: NativeLinker> {
     native_link: NL,
     presenter: NL::Presenter,
     pub(self) g: Graphics,
@@ -239,8 +289,9 @@ pub struct Engine<NL: NativeLinker> {
     request_resize: bool,
     engine_events_sender: async_std::channel::Sender<EngineEvent>,
     receivers: core::cell::UnsafeCell<EngineEventReceiver>,
+    shared_event_queue: &'q EventQueue,
 }
-impl<PL: NativeLinker> Engine<PL> {
+impl<'q, PL: NativeLinker> Engine<'q, PL> {
     pub fn new(
         name: &str,
         version: br::Version,
@@ -251,6 +302,7 @@ impl<PL: NativeLinker> Engine<PL> {
             async_std::channel::Receiver<EngineEvent>,
         ),
         frame_timing_receiver: async_std::channel::Receiver<()>,
+        shared_event_queue: &'q EventQueue,
     ) -> Self {
         let mut g = Graphics::new(
             name,
@@ -278,6 +330,7 @@ impl<PL: NativeLinker> Engine<PL> {
                 frame_timing_receiver,
                 other_events_receiver: engine_events_bus.1,
             }),
+            shared_event_queue,
         }
     }
 
@@ -285,9 +338,14 @@ impl<PL: NativeLinker> Engine<PL> {
         tracing::trace!("PostInit BaseEngine...");
     }
 }
-impl<NL: NativeLinker> Engine<NL> {
+impl<'q, NL: NativeLinker> Engine<'q, NL> {
     pub fn event_receivers(&self) -> &mut EngineEventReceiver {
         unsafe { &mut *self.receivers.get() }
+    }
+
+    #[inline(always)]
+    pub fn wait_for_event2(&self) -> impl core::future::Future<Output = Event> + 'q {
+        self.shared_event_queue.wait_for_event()
     }
 
     pub async fn quit(&self) {
@@ -386,7 +444,7 @@ impl<NL: NativeLinker> Engine<NL> {
         &self.audio_mixer
     }
 }
-impl<PL: NativeLinker> Engine<PL> {
+impl<PL: NativeLinker> Engine<'_, PL> {
     pub fn load<A: FromAsset>(&self, path: &str) -> Result<A, A::Error> {
         A::from_asset(self.native_link.asset_loader().get(path, A::EXT)?)
     }
@@ -402,7 +460,7 @@ impl<PL: NativeLinker> Engine<PL> {
         self.native_link.rendering_precision()
     }
 }
-impl<PL: NativeLinker> Engine<PL> {
+impl<PL: NativeLinker> Engine<'_, PL> {
     pub fn prepare_frame(&mut self) -> Result<FrameData, PrepareFrameError> {
         StateFence::wait(&mut self.last_rendering_completion)
             .expect("Waiting last command completion");
@@ -518,7 +576,7 @@ impl<PL: NativeLinker> Engine<PL> {
         }
     }
 }
-impl<NL: NativeLinker> Drop for Engine<NL> {
+impl<NL: NativeLinker> Drop for Engine<'_, NL> {
     fn drop(&mut self) {
         unsafe {
             self.graphics().device.wait().expect("device error");

--- a/cradle/android/src/lib.rs
+++ b/cradle/android/src/lib.rs
@@ -41,53 +41,141 @@ fn init_logger() {
     }));
 }
 
-struct Game {
+static USERCODE_WAKER_VTABLE: core::task::RawWakerVTable = core::task::RawWakerVTable::new(
+    |data| core::task::RawWaker::new(data, &USERCODE_WAKER_VTABLE),
+    |data| {},
+    |data| {},
+    |data| {},
+);
+
+fn launch<F: core::future::Future>(
+    asset_manager: native_wrapper::AssetManager,
+    window: native_wrapper::Window,
+    usercode_launcher: impl FnOnce(peridot::Engine<'static, NativeLink>) -> F,
+) -> NativeCallData {
+    let (event_sender, event_receiver) = async_std::channel::unbounded();
+    let (frame_timing_sender, frame_timing_receiver) = async_std::channel::bounded(1);
+
+    let event_queue = Box::pin(peridot::EventQueue::new());
+    let event_queue_lifetime_extended: &'static peridot::EventQueue =
+        unsafe { &*(&*event_queue as *const _) };
+    let nl = NativeLink {
+        al: PlatformAssetLoader::new(asset_manager),
+        w: window,
+    };
+    let mut engine = peridot::Engine::new(
+        userlib::APP_IDENTIFIER,
+        userlib::APP_VERSION,
+        nl,
+        Default::default(),
+        (event_sender.clone(), event_receiver),
+        frame_timing_receiver,
+        event_queue_lifetime_extended,
+    );
+    let snd = NativeAudioEngine::new(engine.audio_mixer());
+    let pos_cache = SharedRef::new(DynamicMut::new(TouchPositionCache::new()));
+    engine.input_mut().set_nativelink(Box::new(InputNativeLink {
+        pos_cache: pos_cache.clone(),
+    }));
+    engine.post_init();
+
+    let engine_input = engine.input().clone();
+    let usercode_thread = Box::pin(usercode_launcher(engine));
+
+    let driver = Box::new(Game {
+        engine_input,
+        snd,
+        stopping_render: false,
+        pos_cache,
+        event_sender,
+        frame_timing_sender,
+        event_queue,
+        usercode_thread,
+        _pinned: core::marker::PhantomPinned,
+    });
+
+    extern "C" fn fin<F: core::future::Future>(inst_ptr: *mut core::ffi::c_void) {
+        let mut inst = unsafe { Box::from_raw(inst_ptr as *mut Game<F>) };
+        inst.event_queue.enqueue(peridot::Event::Shutdown);
+        while !inst.step() {}
+    }
+    extern "C" fn update<F: core::future::Future>(inst_ptr: *mut core::ffi::c_void) {
+        let inst = unsafe { &mut *(inst_ptr as *mut Game<F>) };
+        inst.event_queue.enqueue(peridot::Event::NextFrame);
+        inst.step();
+    }
+    extern "C" fn process_touch_down_event<F: core::future::Future>(
+        inst_ptr: *mut core::ffi::c_void,
+        id: u32,
+    ) {
+        let inst = unsafe { &mut *(inst_ptr as *mut Game<F>) };
+        inst.engine_input
+            .dispatch_button_event(peridot::NativeButtonInput::Touch(id), true);
+    }
+    extern "C" fn process_touch_up_event<F: core::future::Future>(
+        inst_ptr: *mut core::ffi::c_void,
+        id: u32,
+    ) {
+        let inst = unsafe { &mut *(inst_ptr as *mut Game<F>) };
+        inst.engine_input
+            .dispatch_button_event(peridot::NativeButtonInput::Touch(id), false);
+    }
+    extern "C" fn set_touch_position_absolute<F: core::future::Future>(
+        inst_ptr: *mut core::ffi::c_void,
+        id: u32,
+        x: f32,
+        y: f32,
+    ) {
+        let inst = unsafe { &mut *(inst_ptr as *mut Game<F>) };
+
+        inst.pos_cache.borrow_mut().set(id as _, x, y);
+        inst.engine_input.dispatch_analog_event(
+            peridot::NativeAnalogInput::TouchMoveX(id),
+            x,
+            true,
+        );
+        inst.engine_input.dispatch_analog_event(
+            peridot::NativeAnalogInput::TouchMoveY(id),
+            y,
+            true,
+        );
+    }
+
+    NativeCallData {
+        inst_ptr: Box::into_raw(driver) as _,
+        finalize: fin::<F>,
+        update: update::<F>,
+        process_touch_down_event: process_touch_down_event::<F>,
+        process_touch_up_event: process_touch_up_event::<F>,
+        set_touch_position_absolute: set_touch_position_absolute::<F>,
+    }
+}
+
+struct Game<F> {
     engine_input: peridot::InputProcess,
     snd: NativeAudioEngine,
     stopping_render: bool,
     pos_cache: SharedRef<DynamicMut<TouchPositionCache>>,
     event_sender: async_std::channel::Sender<peridot::EngineEvent>,
     frame_timing_sender: async_std::channel::Sender<()>,
-    usercode_thread: async_std::task::JoinHandle<()>,
+    event_queue: Pin<Box<peridot::EventQueue>>,
+    usercode_thread: Pin<Box<F>>,
+    // self-referential struct
+    _pinned: core::marker::PhantomPinned,
 }
-impl Game {
-    fn new(asset_manager: native_wrapper::AssetManager, window: native_wrapper::Window) -> Self {
-        let (event_sender, event_receiver) = async_std::channel::unbounded();
-        let (frame_timing_sender, frame_timing_receiver) = async_std::channel::bounded(1);
-
-        let nl = NativeLink {
-            al: PlatformAssetLoader::new(asset_manager),
-            w: window,
+impl<F: core::future::Future> Game<F> {
+    fn step(&mut self) -> bool {
+        let waker = unsafe {
+            core::task::Waker::from_raw(core::task::RawWaker::new(
+                core::ptr::null(),
+                &USERCODE_WAKER_VTABLE,
+            ))
         };
-        let mut engine = peridot::Engine::new(
-            userlib::APP_IDENTIFIER,
-            userlib::APP_VERSION,
-            nl,
-            Default::default(),
-            (event_sender.clone(), event_receiver),
-            frame_timing_receiver,
-        );
-        let snd = NativeAudioEngine::new(engine.audio_mixer());
-        let pos_cache = SharedRef::new(DynamicMut::new(TouchPositionCache::new()));
-        engine.input_mut().set_nativelink(Box::new(InputNativeLink {
-            pos_cache: pos_cache.clone(),
-        }));
-        engine.post_init();
 
-        let engine_input = engine.input().clone();
-        let usercode_thread = async_std::task::spawn(async move {
-            userlib::game_main(&mut engine).await;
-        });
-
-        Self {
-            engine_input,
-            snd,
-            stopping_render: false,
-            pos_cache,
-            event_sender,
-            frame_timing_sender,
-            usercode_thread,
-        }
+        self.usercode_thread
+            .as_mut()
+            .poll(&mut core::task::Context::from_waker(&waker))
+            .is_ready()
     }
 }
 
@@ -288,6 +376,16 @@ use jni::{
     JNIEnv,
 };
 
+struct NativeCallData {
+    inst_ptr: *mut core::ffi::c_void,
+    finalize: extern "C" fn(inst_ptr: *mut core::ffi::c_void),
+    update: extern "C" fn(inst_ptr: *mut core::ffi::c_void),
+    process_touch_down_event: extern "C" fn(inst_ptr: *mut core::ffi::c_void, id: u32),
+    process_touch_up_event: extern "C" fn(inst_ptr: *mut core::ffi::c_void, id: u32),
+    set_touch_position_absolute:
+        extern "C" fn(inst_ptr: *mut core::ffi::c_void, id: u32, x: f32, y: f32),
+}
+
 #[no_mangle]
 pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_init<'e>(
     mut env: JNIEnv<'e>,
@@ -302,11 +400,13 @@ pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_init<'e>(
         .expect("No native window associated to the surface");
     let am = native_wrapper::AssetManager::from_java(&env, &asset_manager)
         .expect("Failed to get AndroidAssetManager native object");
-    let e = Game::new(am, window);
+    let ncd = launch(am, window, |mut e| async move {
+        userlib::game_main(&mut e).await;
+    });
 
-    let ptr = Box::into_raw(Box::new(e));
+    let ptr = Box::into_raw(Box::new(ncd));
     unsafe {
-        env.new_direct_byte_buffer(ptr as *mut u8, core::mem::size_of::<Game>())
+        env.new_direct_byte_buffer(ptr as *mut u8, core::mem::size_of::<NativeCallData>())
             .expect("Creating DirectByteBuffer failed")
     }
 }
@@ -320,17 +420,9 @@ pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_fin(
     let bytes = e
         .get_direct_buffer_address(&obj)
         .expect("Getting Pointer from DirectByteBuffer failed");
-    let e = unsafe { Box::from_raw(bytes as *mut Game) };
+    let ncd = unsafe { Box::from_raw(bytes as *mut NativeCallData) };
 
-    async_std::task::block_on(async move {
-        if e.event_sender
-            .send(peridot::EngineEvent::Shutdown)
-            .await
-            .is_ok()
-        {
-            e.usercode_thread.await;
-        }
-    });
+    (ncd.finalize)(ncd.inst_ptr);
 }
 #[no_mangle]
 pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_update(
@@ -341,15 +433,9 @@ pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_update(
     let bytes = e
         .get_direct_buffer_address(&obj)
         .expect("Getting Pointer from DirectByteBuffer failed");
-    let e = unsafe { (bytes as *mut Game).as_mut().expect("null ptr?") };
+    let ncd = unsafe { (bytes as *mut NativeCallData).as_mut().expect("null ptr?") };
 
-    match e.frame_timing_sender.try_send(()) {
-        Ok(_) => (),
-        Err(async_std::channel::TrySendError::Full(_)) => (),
-        Err(async_std::channel::TrySendError::Closed(_)) => {
-            tracing::warn!("Frame Timing channel was closed!");
-        }
-    }
+    (ncd.update)(ncd.inst_ptr);
 }
 
 mod audio_backend;
@@ -429,10 +515,9 @@ pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_processTouchDownEvent(
     let bytes = e
         .get_direct_buffer_address(&obj)
         .expect("Getting Pointer from DirectByteBuffer failed");
-    let gd = unsafe { (bytes as *mut Game).as_mut().expect("null ptr?") };
+    let ncd = unsafe { (bytes as *mut NativeCallData).as_mut().expect("null ptr?") };
 
-    gd.engine_input
-        .dispatch_button_event(peridot::NativeButtonInput::Touch(id as _), true);
+    (ncd.process_touch_down_event)(ncd.inst_ptr, id as _);
 }
 #[no_mangle]
 pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_processTouchUpEvent(
@@ -444,10 +529,9 @@ pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_processTouchUpEvent(
     let bytes = e
         .get_direct_buffer_address(&obj)
         .expect("Getting Pointer from DirectByteBuffer failed");
-    let gd = unsafe { (bytes as *mut Game).as_mut().expect("null ptr?") };
+    let ncd = unsafe { (bytes as *mut NativeCallData).as_mut().expect("null ptr?") };
 
-    gd.engine_input
-        .dispatch_button_event(peridot::NativeButtonInput::Touch(id as _), false);
+    (ncd.process_touch_up_event)(ncd.inst_ptr, id as _);
 }
 #[no_mangle]
 pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_setTouchPositionAbsolute(
@@ -461,11 +545,7 @@ pub extern "system" fn Java_io_ct2_peridot_NativeLibLink_setTouchPositionAbsolut
     let bytes = e
         .get_direct_buffer_address(&obj)
         .expect("Getting Pointer from DirectByteBuffer failed");
-    let gd = unsafe { (bytes as *mut Game).as_mut().expect("null ptr?") };
+    let ncd = unsafe { (bytes as *mut NativeCallData).as_mut().expect("null ptr?") };
 
-    gd.pos_cache.borrow_mut().set(id as _, x, y);
-    gd.engine_input
-        .dispatch_analog_event(peridot::NativeAnalogInput::TouchMoveX(id as _), x, true);
-    gd.engine_input
-        .dispatch_analog_event(peridot::NativeAnalogInput::TouchMoveY(id as _), y, true);
+    (ncd.set_touch_position_absolute)(ncd.inst_ptr, id as _, x, y);
 }

--- a/cradle/linux/src/input.rs
+++ b/cradle/linux/src/input.rs
@@ -50,6 +50,47 @@ impl<T: PointerPositionProvider> PointerPositionProvider for RwLock<T> {
         self.read().query_input_focus_and_pointer_entered()
     }
 }
+impl<T: PointerPositionProvider> PointerPositionProvider for std::rc::Weak<T> {
+    fn get_pointer_position(&self) -> Option<(f32, f32)> {
+        self.upgrade().and_then(|x| x.get_pointer_position())
+    }
+
+    fn query_input_focus(&self) -> bool {
+        self.upgrade().map_or(false, |x| x.query_input_focus())
+    }
+
+    fn query_input_focus_and_pointer_entered(&self) -> (bool, bool) {
+        self.upgrade().map_or((false, false), |x| {
+            x.query_input_focus_and_pointer_entered()
+        })
+    }
+}
+impl<T: PointerPositionProvider> PointerPositionProvider for std::rc::Rc<T> {
+    fn get_pointer_position(&self) -> Option<(f32, f32)> {
+        T::get_pointer_position(&*self)
+    }
+
+    fn query_input_focus(&self) -> bool {
+        T::query_input_focus(&*self)
+    }
+
+    fn query_input_focus_and_pointer_entered(&self) -> (bool, bool) {
+        T::query_input_focus_and_pointer_entered(&*self)
+    }
+}
+impl<T: PointerPositionProvider> PointerPositionProvider for std::cell::RefCell<T> {
+    fn get_pointer_position(&self) -> Option<(f32, f32)> {
+        self.borrow().get_pointer_position()
+    }
+
+    fn query_input_focus(&self) -> bool {
+        self.borrow().query_input_focus()
+    }
+
+    fn query_input_focus_and_pointer_entered(&self) -> (bool, bool) {
+        self.borrow().query_input_focus_and_pointer_entered()
+    }
+}
 
 pub struct InputNativeLink<PosProvider: PointerPositionProvider> {
     position_provider: PosProvider,

--- a/cradle/linux/src/main.rs
+++ b/cradle/linux/src/main.rs
@@ -1,3 +1,4 @@
+use core::{future::Future, pin::Pin};
 use input::PointerPositionProvider;
 use parking_lot::RwLock;
 use peridot::mthelper::{make_shared_mutable_ref, DynamicMutabilityProvider, SharedMutableRef};
@@ -97,36 +98,54 @@ impl<PP: PresenterProvider> peridot::NativeLinker for NativeLink<PP> {
     }
 }
 
-pub struct GameDriver {
+static USERCODE_WAKER_VTABLE: core::task::RawWakerVTable = core::task::RawWakerVTable::new(
+    |ptr| core::task::RawWaker::new(ptr, &USERCODE_WAKER_VTABLE),
+    |_| {},
+    |_| {},
+    |_| {},
+);
+
+pub struct GameDriver<MainF> {
     engine_input: peridot::InputProcess,
     engine_audio: Arc<RwLock<peridot::audio::Mixer>>,
     _snd: Box<dyn SoundBackend>,
     event_sender: async_std::channel::Sender<peridot::EngineEvent>,
     frame_timing_sender: async_std::channel::Sender<()>,
-    usercode_thread: async_std::task::JoinHandle<()>,
+    event_queue: Pin<Box<peridot::EventQueue>>,
+    usercode: Pin<Box<MainF>>,
+    // self-referential struct
+    _pinned: core::marker::PhantomPinned,
 }
-impl GameDriver {
-    fn new<PP>(pp: Arc<RwLock<PP>>) -> Self
+impl<MainF: Future> GameDriver<MainF> {
+    fn new<PP>(
+        pp: SharedMutableRef<PP>,
+        usercode_launcher: impl FnOnce(
+            peridot::Engine<'static, NativeLink<SharedMutableRef<PP>>>,
+        ) -> MainF,
+    ) -> Self
     where
         PP: PointerPositionProvider + Send + Sync + 'static,
-        Arc<RwLock<PP>>: PresenterProvider,
-        <Arc<RwLock<PP>> as PresenterProvider>::Presenter: Sync + Send,
-        <<Arc<RwLock<PP>> as PresenterProvider>::Presenter as peridot::PlatformPresenter>::BackBuffer: Sync + Send
+        SharedMutableRef<PP>: PresenterProvider<
+            Presenter: Sync + Send + peridot::PlatformPresenter<BackBuffer: Sync + Send>,
+        >,
     {
         let (event_sender, event_receiver) = async_std::channel::unbounded();
         let (frame_timing_sender, frame_timing_receiver) = async_std::channel::bounded(1);
 
-        let nl = NativeLink {
-            al: PlatformAssetLoader::new(),
-            pp: pp.clone(),
-        };
+        let event_queue = Box::pin(peridot::EventQueue::new());
+        let event_queue_lifetime_extended: &'static peridot::EventQueue =
+            unsafe { &*(&*event_queue as *const _) };
         let mut engine = peridot::Engine::new(
             userlib::APP_IDENTIFIER,
             userlib::APP_VERSION,
-            nl,
+            NativeLink {
+                al: PlatformAssetLoader::new(),
+                pp: pp.clone(),
+            },
             Default::default(),
             (event_sender.clone(), event_receiver),
             frame_timing_receiver,
+            &event_queue_lifetime_extended,
         );
         engine
             .input()
@@ -146,9 +165,7 @@ impl GameDriver {
 
         let engine_input = engine.input().clone();
         let engine_audio = engine.audio_mixer().clone();
-        let usercode_thread = async_std::task::spawn(async move {
-            userlib::game_main(&mut engine).await;
-        });
+        let mut usercode = Box::pin(usercode_launcher(engine));
 
         Self {
             engine_input,
@@ -156,8 +173,21 @@ impl GameDriver {
             _snd,
             event_sender,
             frame_timing_sender,
-            usercode_thread,
+            event_queue,
+            usercode,
+            _pinned: core::marker::PhantomPinned,
         }
+    }
+
+    /// returns true if usercode coroutine has done
+    pub fn step(&mut self) -> bool {
+        let usercode_waker =
+            unsafe { core::task::Waker::new(core::ptr::null(), &USERCODE_WAKER_VTABLE) };
+
+        self.usercode
+            .as_mut()
+            .poll(&mut core::task::Context::from_waker(&usercode_waker))
+            .is_ready()
     }
 }
 
@@ -184,15 +214,16 @@ impl Drop for EpollTemporaryAddFd<'_> {
     }
 }
 
-async fn run_with_window_backend<W>(window_backend: Arc<RwLock<W>>)
+fn run_with_window_backend<W>(window_backend: SharedMutableRef<W>)
 where
     W: WindowBackend + EventProcessor + PointerPositionProvider + Send + Sync + 'static,
-    Arc<RwLock<W>>: PresenterProvider,
-    <Arc<RwLock<W>> as PresenterProvider>::Presenter: Sync + Send,
-    <<Arc<RwLock<W>> as PresenterProvider>::Presenter as peridot::PlatformPresenter>::BackBuffer:
-        Sync + Send,
+    SharedMutableRef<W>: PresenterProvider<
+        Presenter: Sync + Send + peridot::PlatformPresenter<BackBuffer: Sync + Send>,
+    >,
 {
-    let gd = GameDriver::new(window_backend.clone());
+    let mut gd = GameDriver::new(window_backend.clone(), |mut engine| async move {
+        userlib::game_main(&mut engine).await;
+    });
 
     let ep = epoll::Epoll::new().expect("Failed to create epoll interface");
     let mut input = input::InputSystem::new(&ep, 1, 2);
@@ -202,6 +233,9 @@ where
     let mut events = Vec::new();
     let mut last_drawn_geometry = window_backend.read().geometry();
     while !window_backend.read().has_close_requested() {
+        // step usercode before wait
+        gd.step();
+
         if events.len() != 2 + input.managed_devices_count() {
             // resize
             events.resize(2 + input.managed_devices_count(), unsafe {
@@ -228,22 +262,11 @@ where
             let current_geometry = window_backend.read().geometry();
             if last_drawn_geometry != current_geometry {
                 last_drawn_geometry = current_geometry;
-                if let Err(e) = gd
-                    .event_sender
-                    .send(peridot::EngineEvent::Resize(last_drawn_geometry))
-                    .await
-                {
-                    warn!("Failed to send resize event: {e:?}");
-                }
+                gd.event_queue
+                    .enqueue(peridot::Event::Resize(last_drawn_geometry));
             }
 
-            match gd.frame_timing_sender.try_send(()) {
-                Ok(_) => (),
-                Err(async_std::channel::TrySendError::Full(_)) => (),
-                Err(async_std::channel::TrySendError::Closed(_)) => {
-                    warn!("Frame Timing channel was closed!");
-                }
-            }
+            gd.event_queue.enqueue(peridot::Event::NextFrame);
             continue;
         }
 
@@ -266,21 +289,14 @@ where
         }
     }
 
-    if gd
-        .event_sender
-        .send(peridot::EngineEvent::Shutdown)
-        .await
-        .is_ok()
-    {
-        gd.usercode_thread.await;
-    }
+    gd.event_queue.enqueue(peridot::Event::Shutdown);
+    while !gd.step() {}
 
     gd.engine_audio.write().stop();
     tracing::trace!("Terminating Program...");
 }
 
-#[async_std::main]
-async fn main() {
+fn main() {
     let fmt = tracing_subscriber::fmt::layer().pretty();
     let env_filter = tracing_subscriber::filter::EnvFilter::from_default_env();
     tracing_subscriber::registry()
@@ -290,18 +306,16 @@ async fn main() {
 
     if let Ok(backend_name) = std::env::var("PERIDOT_PREFERRED_WINDOW_BACKEND") {
         if backend_name == "wayland" {
-            run_with_window_backend(Arc::new(RwLock::new(
+            run_with_window_backend(make_shared_mutable_ref(
                 Wayland::try_init().expect("Failed to initialize wayland backend"),
-            )))
-            .await;
+            ));
             return;
         }
         #[cfg(feature = "support-xcb")]
         if backend_name == "xcb" {
-            run_with_window_backend(Arc::new(RwLock::new(
+            run_with_window_backend(make_shared_mutable_ref(
                 presenter::xcb::X11::try_init().expect("Failed to initialize xcb backend"),
-            )))
-            .await;
+            ));
             return;
         }
 
@@ -312,12 +326,12 @@ async fn main() {
     }
 
     if let Some(x) = Wayland::try_init() {
-        run_with_window_backend(Arc::new(RwLock::new(x))).await;
+        run_with_window_backend(make_shared_mutable_ref(x));
         return;
     }
     #[cfg(feature = "support-xcb")]
     if let Some(x) = presenter::xcb::X11::try_init() {
-        run_with_window_backend(Arc::new(RwLock::new(x))).await;
+        run_with_window_backend(make_shared_mutable_ref(x));
         return;
     }
 

--- a/cradle/linux/src/main.rs
+++ b/cradle/linux/src/main.rs
@@ -124,10 +124,8 @@ impl<MainF: Future> GameDriver<MainF> {
         ) -> MainF,
     ) -> Self
     where
-        PP: PointerPositionProvider + Send + Sync + 'static,
-        SharedMutableRef<PP>: PresenterProvider<
-            Presenter: Sync + Send + peridot::PlatformPresenter<BackBuffer: Sync + Send>,
-        >,
+        PP: PointerPositionProvider + 'static,
+        SharedMutableRef<PP>: PresenterProvider<Presenter: peridot::PlatformPresenter>,
     {
         let (event_sender, event_receiver) = async_std::channel::unbounded();
         let (frame_timing_sender, frame_timing_receiver) = async_std::channel::bounded(1);
@@ -216,10 +214,8 @@ impl Drop for EpollTemporaryAddFd<'_> {
 
 fn run_with_window_backend<W>(window_backend: SharedMutableRef<W>)
 where
-    W: WindowBackend + EventProcessor + PointerPositionProvider + Send + Sync + 'static,
-    SharedMutableRef<W>: PresenterProvider<
-        Presenter: Sync + Send + peridot::PlatformPresenter<BackBuffer: Sync + Send>,
-    >,
+    W: WindowBackend + EventProcessor + PointerPositionProvider + 'static,
+    SharedMutableRef<W>: PresenterProvider<Presenter: peridot::PlatformPresenter>,
 {
     let mut gd = GameDriver::new(window_backend.clone(), |mut engine| async move {
         userlib::game_main(&mut engine).await;
@@ -228,11 +224,11 @@ where
     let ep = epoll::Epoll::new().expect("Failed to create epoll interface");
     let mut input = input::InputSystem::new(&ep, 1, 2);
 
-    window_backend.write().show();
+    window_backend.borrow_mut().show();
     gd.engine_audio.write().start();
     let mut events = Vec::new();
-    let mut last_drawn_geometry = window_backend.read().geometry();
-    while !window_backend.read().has_close_requested() {
+    let mut last_drawn_geometry = window_backend.borrow().geometry();
+    while !window_backend.borrow().has_close_requested() {
         // step usercode before wait
         gd.step();
 
@@ -243,7 +239,7 @@ where
             });
         }
 
-        let window_backend_readiness_guard = window_backend.write().readiness_guard();
+        let window_backend_readiness_guard = window_backend.borrow_mut().readiness_guard();
         let window_backend_temporary_epoll = EpollTemporaryAddFd::add(
             &ep,
             window_backend_readiness_guard.borrow_fd().as_raw_fd(),
@@ -259,7 +255,7 @@ where
         // FIXME: あとでちゃんと待つ(external_fence_fdでは待てなさそうなので、監視スレッド立てるかしかないか......)
         if count == 0 {
             drop(window_backend_readiness_guard);
-            let current_geometry = window_backend.read().geometry();
+            let current_geometry = window_backend.borrow().geometry();
             if last_drawn_geometry != current_geometry {
                 last_drawn_geometry = current_geometry;
                 gd.event_queue
@@ -274,7 +270,7 @@ where
         for e in &events[..count as usize] {
             if e.u64 == 0 {
                 window_backend
-                    .write()
+                    .borrow_mut()
                     .process_all_events(rg.take().expect("window events signaled twice"));
             } else if e.u64 == 1 {
                 input.process_monitor_event(&ep);
@@ -283,7 +279,7 @@ where
                 input.process_device_event(
                     &mut input_lock.make_event_receiver(),
                     e.u64,
-                    &*window_backend.read(),
+                    &*window_backend.borrow(),
                 );
             }
         }

--- a/cradle/linux/src/main.rs
+++ b/cradle/linux/src/main.rs
@@ -163,7 +163,7 @@ impl<MainF: Future> GameDriver<MainF> {
 
         let engine_input = engine.input().clone();
         let engine_audio = engine.audio_mixer().clone();
-        let mut usercode = Box::pin(usercode_launcher(engine));
+        let usercode = Box::pin(usercode_launcher(engine));
 
         Self {
             engine_input,

--- a/cradle/linux/src/presenter/wayland.rs
+++ b/cradle/linux/src/presenter/wayland.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, ffi::CStr, sync::Arc};
+use std::{collections::HashMap, ffi::CStr};
 
 use bedrock as br;
 use br::PhysicalDevice;
-use parking_lot::RwLock;
+use peridot::mthelper::{DynamicMutabilityProvider, SharedMutableRef};
 use wayland_backend::client::ReadEventsGuard;
 use wayland_client::{
     protocol::{
@@ -246,7 +246,7 @@ impl WindowBackend for Wayland {
         self.state.geometry
     }
 }
-impl PresenterProvider for Arc<RwLock<Wayland>> {
+impl PresenterProvider for SharedMutableRef<Wayland> {
     type Presenter = Presenter;
     const SURFACE_EXT_NAME: &'static CStr = c"VK_KHR_wayland_surface";
 
@@ -283,12 +283,16 @@ impl EventProcessor for Wayland {
 }
 
 pub struct Presenter {
-    window_backend: Arc<RwLock<Wayland>>,
+    window_backend: SharedMutableRef<Wayland>,
     sc: peridot::IntegratedSwapchain<br::SurfaceObject<peridot::InstanceObject>>,
 }
 impl Presenter {
-    fn new(g: &peridot::Graphics, renderer_queue_family: u32, w: &Arc<RwLock<Wayland>>) -> Self {
-        let wlock = w.read();
+    fn new(
+        g: &peridot::Graphics,
+        renderer_queue_family: u32,
+        w: &SharedMutableRef<Wayland>,
+    ) -> Self {
+        let wlock = w.borrow();
 
         if !unsafe {
             g.adapter().wayland_presentation_support(
@@ -381,7 +385,7 @@ impl peridot::PlatformPresenter for Presenter {
     }
 
     fn current_geometry_extent(&self) -> peridot::math::Vector2<u32> {
-        self.window_backend.read().state.geometry
+        self.window_backend.borrow().state.geometry
     }
 }
 impl PointerPositionProvider for Wayland {

--- a/cradle/mac/peridot-cradle/peridot-cradle/NativeInterface.swift
+++ b/cradle/mac/peridot-cradle/peridot-cradle/NativeInterface.swift
@@ -9,34 +9,59 @@
 import Foundation
 import Cocoa
 
-final class NativeGameEngine {
-    private var p: OpaquePointer
+struct NativeGameDriver {
+    private let callbacks: UnsafeMutablePointer<GameDriverCallbacks>
+    private let contextPtr: UnsafeMutableRawPointer
     
-    init(forLayer layer: CAMetalLayer, on initializationContext: UnsafeMutableRawPointer) {
-        self.p = launch_game(initializationContext, unsafeBitCast(layer, to: UnsafeMutablePointer.self))
-    }
-    
-    func handleCharacterKeyDown(character: UInt8) {
-        handle_character_keydown(self.p, character)
-    }
-    func handleCharacterKeyUp(character: UInt8) {
-        handle_character_keyup(self.p, character)
-    }
-    func handleKeymodDown(code: UInt8) {
-        handle_keymod_down(self.p, code)
-    }
-    func handleKeymodUp(code: UInt8) {
-        handle_keymod_up(self.p, code)
+    init(callbacks: UnsafeMutablePointer<GameDriverCallbacks>, contextPtr: UnsafeMutableRawPointer) {
+        self.callbacks = callbacks
+        self.contextPtr = contextPtr
     }
     
-    func handleMouseButtonDown(index: UInt8) { handle_mouse_button_down(self.p, index) }
-    func handleMouseButtonUp(index: UInt8) { handle_mouse_button_up(self.p, index) }
-    func reportMouseMove(x: Float, y: Float) { report_mouse_move_abs(self.p, x, y) }
-    
-    static func captionbarText() -> NSString? {
-        let p = captionbar_text()
-        return p.map { x in Unmanaged<NSString>.fromOpaque(x).takeUnretainedValue() }
+    func terminate() {
+        self.callbacks.pointee.terminate(self.contextPtr)
     }
+    
+    func update() {
+        self.callbacks.pointee.update(self.contextPtr)
+    }
+    
+    func resize(_ size: NSSize) {
+        self.callbacks.pointee.resize(self.contextPtr, UInt32(size.width), UInt32(size.height))
+    }
+    
+    func handleKeyDown(character c: UniChar) {
+        self.callbacks.pointee.handle_character_keydown(self.contextPtr, UInt8(c))
+    }
+    
+    func handleKeyUp(character c: UniChar) {
+        self.callbacks.pointee.handle_character_keyup(self.contextPtr, UInt8(c))
+    }
+    
+    func handleKeyDown(mod code: UInt8) {
+        self.callbacks.pointee.handle_keymod_down(self.contextPtr, code)
+    }
+    
+    func handleKeyUp(mod code: UInt8) {
+        self.callbacks.pointee.handle_keymod_up(self.contextPtr, code)
+    }
+    
+    func handleMouseButtonDown(_ index: UInt8) {
+        self.callbacks.pointee.handle_mouse_button_down(self.contextPtr, index)
+    }
+    
+    func handleMouseButtonUp(_ index: UInt8) {
+        self.callbacks.pointee.handle_mouse_button_up(self.contextPtr, index)
+    }
+    
+    func reportMouseMoveAbs(x: Float, y: Float) {
+        self.callbacks.pointee.report_mouse_move_abs(self.contextPtr, x, y)
+    }
+}
+
+func captionbarText() -> NSString? {
+    let p = captionbar_text()
+    return p.map { x in Unmanaged<NSString>.fromOpaque(x).takeUnretainedValue() }
 }
 
 @_cdecl("nsapp_reply_should_terminate")

--- a/cradle/mac/peridot-cradle/peridot-cradle/NativeInterface.swift
+++ b/cradle/mac/peridot-cradle/peridot-cradle/NativeInterface.swift
@@ -12,18 +12,8 @@ import Cocoa
 final class NativeGameEngine {
     private var p: OpaquePointer
     
-    init(forLayer layer: CAMetalLayer) {
-        self.p = launch_game(unsafeBitCast(layer, to: UnsafeMutablePointer.self))
-    }
-    deinit {
-        NSLog("GameEngine Terminating")
-        terminate_game(self.p)
-        NSLog("GameEngine Terminated")
-    }
-    
-    func update() { update_game(self.p) }
-    func resize(_ newSize: NSSize) {
-        resize_game(self.p, UInt32(newSize.width), UInt32(newSize.height))
+    init(forLayer layer: CAMetalLayer, on initializationContext: UnsafeMutableRawPointer) {
+        self.p = launch_game(initializationContext, unsafeBitCast(layer, to: UnsafeMutablePointer.self))
     }
     
     func handleCharacterKeyDown(character: UInt8) {
@@ -81,4 +71,9 @@ func obtain_mouse_pointer_position(
         x.pointee = Float32(pl.x) * nsscreen_backing_scale_factor()
         y.pointee = Float32(h - pl.y) * nsscreen_backing_scale_factor()
     }
+}
+
+@_cdecl("give_game_driver_callbacks")
+func give_game_driver_callbacks(initializationContext: UnsafeMutableRawPointer, callbacks: UnsafeMutablePointer<GameDriverCallbacks>, contextPtr: UnsafeMutableRawPointer) {
+    unsafeBitCast(initializationContext, to: PeridotRenderableViewController.self).setGameDriverCallbacks(callbacks, contextPtr: contextPtr)
 }

--- a/cradle/mac/peridot-cradle/peridot-cradle/PeridotRenderableView.swift
+++ b/cradle/mac/peridot-cradle/peridot-cradle/PeridotRenderableView.swift
@@ -11,7 +11,6 @@ import Cocoa
 import QuartzCore
 
 final class PeridotRenderableView : NSView {
-    weak var enginePointer: NativeGameEngine? = nil
     weak var viewController: PeridotRenderableViewController? = nil
     
     override func draw(_ dirtyRect: NSRect) {

--- a/cradle/mac/peridot-cradle/peridot-cradle/PeridotRenderableView.swift
+++ b/cradle/mac/peridot-cradle/peridot-cradle/PeridotRenderableView.swift
@@ -12,6 +12,7 @@ import QuartzCore
 
 final class PeridotRenderableView : NSView {
     weak var enginePointer: NativeGameEngine? = nil
+    weak var viewController: PeridotRenderableViewController? = nil
     
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
@@ -40,7 +41,7 @@ final class PeridotRenderableView : NSView {
             l.bounds = rect
         }
         if !self.inLiveResize {
-            if let e = self.enginePointer { e.resize(newSize) }
+            self.viewController?.resizeNative(newSize)
         }
     }
 }

--- a/cradle/mac/peridot-cradle/peridot-cradle/PeridotRenderableViewController.swift
+++ b/cradle/mac/peridot-cradle/peridot-cradle/PeridotRenderableViewController.swift
@@ -51,6 +51,9 @@ final class PeridotRenderableViewController : NSViewController {
     var workDispatcher: DispatchSourceUserDataAdd? = nil
     var clientMousePoint = CGPoint(x: 0, y: 0)
     
+    private var gameDriverCallbacks: UnsafeMutablePointer<GameDriverCallbacks>? = nil
+    private var gameDriverCallbackContextPtr: UnsafeMutableRawPointer? = nil
+    
     func initDispatchers() {
         func onUpdateDisplay(_ _: CVDisplayLink,
                              _ inNow: UnsafePointer<CVTimeStamp>,
@@ -63,7 +66,7 @@ final class PeridotRenderableViewController : NSViewController {
             return kCVReturnSuccess
         }
         let workDispatcher = DispatchSource.makeUserDataAddSource(queue: DispatchQueue.main)
-        workDispatcher.setEventHandler(handler: { () in self.enginePointer!.update() })
+        workDispatcher.setEventHandler(handler: { [weak self] in self?.updateNative() })
         self.workDispatcher = workDispatcher
         CVDisplayLinkCreateWithActiveCGDisplays(&self.dplink)
         CVDisplayLinkSetOutputCallback(self.dplink!, onUpdateDisplay,
@@ -73,7 +76,7 @@ final class PeridotRenderableViewController : NSViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.enginePointer = NativeGameEngine(forLayer: self.view.layer! as! CAMetalLayer)
+        launch_game(unsafeBitCast(self, to: UnsafeMutableRawPointer.self), unsafeBitCast(self.view.layer! as! CAMetalLayer, to: UnsafeMutableRawPointer.self))
         self.view.window?.title = NativeGameEngine.captionbarText()! as String
         initDispatchers()
         
@@ -182,12 +185,15 @@ final class PeridotRenderableViewController : NSViewController {
         }
         
         (self.view as! PeridotRenderableView).enginePointer = self.enginePointer
+        (self.view as! PeridotRenderableView).viewController = self
     }
     override func viewDidAppear() {
         super.viewDidAppear()
         NSLog("BeginTimer")
-        if let d = self.workDispatcher { d.resume() }
-        if let d = self.dplink { CVDisplayLinkStart(d) }
+        self.workDispatcher?.resume()
+        if let d = self.dplink {
+            CVDisplayLinkStart(d)
+        }
     }
     override func viewWillDisappear() {
         super.viewWillDisappear()
@@ -197,6 +203,34 @@ final class PeridotRenderableViewController : NSViewController {
             let rv = CVDisplayLinkStop(d)
             NSLog("Stopped Timer with %d", rv)
         }
-        if let d = self.workDispatcher { d.cancel() }
+        self.workDispatcher?.cancel()
+    }
+    
+    func setGameDriverCallbacks(_ callbacks: UnsafeMutablePointer<GameDriverCallbacks>, contextPtr: UnsafeMutableRawPointer) {
+        NSLog("setGameDrivercallbacks")
+        self.gameDriverCallbacks = callbacks
+        self.gameDriverCallbackContextPtr = contextPtr
+    }
+    
+    func updateNative() {
+        guard let cb = self.gameDriverCallbacks else {
+            return
+        }
+        guard let ctx = self.gameDriverCallbackContextPtr else {
+            return
+        }
+        
+        cb.pointee.update(ctx)
+    }
+    
+    func resizeNative(_ size: NSSize) {
+        guard let cb = self.gameDriverCallbacks else {
+            return
+        }
+        guard let ctx = self.gameDriverCallbackContextPtr else {
+            return
+        }
+        
+        cb.pointee.resize(ctx, UInt32(size.width), UInt32(size.height))
     }
 }

--- a/cradle/mac/peridot-cradle/peridot-cradle/PeridotRenderableViewController.swift
+++ b/cradle/mac/peridot-cradle/peridot-cradle/PeridotRenderableViewController.swift
@@ -47,12 +47,10 @@ final class CurrentKeyboardLayoutCodeConverter {
 
 final class PeridotRenderableViewController : NSViewController {
     var dplink: CVDisplayLink? = nil
-    var enginePointer: NativeGameEngine? = nil
     var workDispatcher: DispatchSourceUserDataAdd? = nil
     var clientMousePoint = CGPoint(x: 0, y: 0)
     
-    private var gameDriverCallbacks: UnsafeMutablePointer<GameDriverCallbacks>? = nil
-    private var gameDriverCallbackContextPtr: UnsafeMutableRawPointer? = nil
+    private var nativeGameDriver: NativeGameDriver? = nil
     
     func initDispatchers() {
         func onUpdateDisplay(_ _: CVDisplayLink,
@@ -66,7 +64,7 @@ final class PeridotRenderableViewController : NSViewController {
             return kCVReturnSuccess
         }
         let workDispatcher = DispatchSource.makeUserDataAddSource(queue: DispatchQueue.main)
-        workDispatcher.setEventHandler(handler: { [weak self] in self?.updateNative() })
+        workDispatcher.setEventHandler(handler: { [weak self] in self?.nativeGameDriver?.update() })
         self.workDispatcher = workDispatcher
         CVDisplayLinkCreateWithActiveCGDisplays(&self.dplink)
         CVDisplayLinkSetOutputCallback(self.dplink!, onUpdateDisplay,
@@ -77,7 +75,7 @@ final class PeridotRenderableViewController : NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         launch_game(unsafeBitCast(self, to: UnsafeMutableRawPointer.self), unsafeBitCast(self.view.layer! as! CAMetalLayer, to: UnsafeMutableRawPointer.self))
-        self.view.window?.title = NativeGameEngine.captionbarText()! as String
+        self.view.window?.title = captionbarText()! as String
         initDispatchers()
         
         if let p = self.view.window?.mouseLocationOutsideOfEventStream {
@@ -95,79 +93,79 @@ final class PeridotRenderableViewController : NSViewController {
             .otherMouseDown, .otherMouseUp, .otherMouseDragged,
             .scrollWheel, .magnify, .smartMagnify
         ]
-        NSEvent.addLocalMonitorForEvents(matching: eventTypes) { event in
+        NSEvent.addLocalMonitorForEvents(matching: eventTypes) { [weak self] event in
             switch event.type {
             case .keyDown:
                 if !event.isARepeat {
                     if let cs = kcTranslator.translate(event.keyCode) {
                         NSLog("CharacterKeyDown: \(String(utf16CodeUnits: cs, count: CurrentKeyboardLayoutCodeConverter.MAX_CHAR_LENGTH))")
-                        self.enginePointer?.handleCharacterKeyDown(character: UInt8(cs.pointee))
+                        self?.nativeGameDriver?.handleKeyDown(character: cs.pointee)
                     }
                 }
             case .keyUp:
                 if !event.isARepeat {
                     if let cs = kcTranslator.translate(event.keyCode) {
                         NSLog("CharacterKeyUp: \(String(utf16CodeUnits: cs, count: CurrentKeyboardLayoutCodeConverter.MAX_CHAR_LENGTH))")
-                        self.enginePointer?.handleCharacterKeyUp(character: UInt8(cs.pointee))
+                        self?.nativeGameDriver?.handleKeyUp(character: cs.pointee)
                     }
                 }
             case .flagsChanged:
                 NSLog("FlagsChanged event with \(event)")
                 if event.modifierFlags.contains(.shift) && !oldFlags.contains(.shift) {
                     // shift on
-                    self.enginePointer?.handleKeymodDown(code: KEYMOD_SHIFT)
+                    self?.nativeGameDriver?.handleKeyDown(mod: KEYMOD_SHIFT)
                 }
                 if !event.modifierFlags.contains(.shift) && oldFlags.contains(.shift) {
                     // shift off
-                    self.enginePointer?.handleKeymodUp(code: KEYMOD_SHIFT)
+                    self?.nativeGameDriver?.handleKeyUp(mod: KEYMOD_SHIFT)
                 }
                 if event.modifierFlags.contains(.option) && !oldFlags.contains(.option) {
                     // opt on
-                    self.enginePointer?.handleKeymodDown(code: KEYMOD_OPTION)
+                    self?.nativeGameDriver?.handleKeyDown(mod: KEYMOD_OPTION)
                 }
                 if !event.modifierFlags.contains(.option) && oldFlags.contains(.option) {
                     // opt off
-                    self.enginePointer?.handleKeymodUp(code: KEYMOD_OPTION)
+                    self?.nativeGameDriver?.handleKeyUp(mod: KEYMOD_OPTION)
                 }
                 if event.modifierFlags.contains(.command) && !oldFlags.contains(.command) {
                     // cmd on
-                    self.enginePointer?.handleKeymodDown(code: KEYMOD_COMMAND)
+                    self?.nativeGameDriver?.handleKeyDown(mod: KEYMOD_COMMAND)
                 }
                 if !event.modifierFlags.contains(.command) && oldFlags.contains(.command) {
                     // cmd off
-                    self.enginePointer?.handleKeymodUp(code: KEYMOD_COMMAND)
+                    self?.nativeGameDriver?.handleKeyUp(mod: KEYMOD_COMMAND)
                 }
                 if event.modifierFlags.contains(.control) && !oldFlags.contains(.control) {
                     // ctrl on
-                    self.enginePointer?.handleKeymodDown(code: KEYMOD_CONTROL)
+                    self?.nativeGameDriver?.handleKeyDown(mod: KEYMOD_CONTROL)
                 }
                 if !event.modifierFlags.contains(.control) && oldFlags.contains(.control) {
                     // ctrl off
-                    self.enginePointer?.handleKeymodUp(code: KEYMOD_CONTROL)
+                    self?.nativeGameDriver?.handleKeyUp(mod: KEYMOD_CONTROL)
                 }
                 if event.modifierFlags.contains(.capsLock) && !oldFlags.contains(.capsLock) {
                     // caps on
-                    self.enginePointer?.handleKeymodDown(code: KEYMOD_CAPSLOCK)
+                    self?.nativeGameDriver?.handleKeyDown(mod: KEYMOD_CAPSLOCK)
                 }
                 if !event.modifierFlags.contains(.capsLock) && oldFlags.contains(.capsLock) {
                     // caps off
-                    self.enginePointer?.handleKeymodUp(code: KEYMOD_CAPSLOCK)
+                    self?.nativeGameDriver?.handleKeyUp(mod: KEYMOD_CAPSLOCK)
                 }
                 oldFlags = event.modifierFlags
             case .mouseMoved, .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
-                self.clientMousePoint = event.locationInWindow
-                self.enginePointer?.reportMouseMove(
+                self?.clientMousePoint = event.locationInWindow
+                self?.nativeGameDriver?.reportMouseMoveAbs(
                     x: Float(event.locationInWindow.x),
                     y: -Float(event.locationInWindow.y)
                 )
             case .leftMouseDown:
-                self.enginePointer?.handleMouseButtonDown(index: 0)
+                self?.nativeGameDriver?.handleMouseButtonDown(0)
             case .leftMouseUp:
-                self.enginePointer?.handleMouseButtonUp(index: 0)
+                self?.nativeGameDriver?.handleMouseButtonUp(0)
             case .rightMouseDown:
-                self.enginePointer?.handleMouseButtonDown(index: 1)
+                self?.nativeGameDriver?.handleMouseButtonDown(1)
             case .rightMouseUp:
-                self.enginePointer?.handleMouseButtonUp(index: 1)
+                self?.nativeGameDriver?.handleMouseButtonUp(1)
             case .otherMouseDown:
                 NSLog("OtherMouseDown event with \(event)")
             case .otherMouseUp:
@@ -184,7 +182,6 @@ final class PeridotRenderableViewController : NSViewController {
             return event
         }
         
-        (self.view as! PeridotRenderableView).enginePointer = self.enginePointer
         (self.view as! PeridotRenderableView).viewController = self
     }
     override func viewDidAppear() {
@@ -207,30 +204,10 @@ final class PeridotRenderableViewController : NSViewController {
     }
     
     func setGameDriverCallbacks(_ callbacks: UnsafeMutablePointer<GameDriverCallbacks>, contextPtr: UnsafeMutableRawPointer) {
-        NSLog("setGameDrivercallbacks")
-        self.gameDriverCallbacks = callbacks
-        self.gameDriverCallbackContextPtr = contextPtr
-    }
-    
-    func updateNative() {
-        guard let cb = self.gameDriverCallbacks else {
-            return
-        }
-        guard let ctx = self.gameDriverCallbackContextPtr else {
-            return
-        }
-        
-        cb.pointee.update(ctx)
+        self.nativeGameDriver = NativeGameDriver(callbacks: callbacks, contextPtr: contextPtr)
     }
     
     func resizeNative(_ size: NSSize) {
-        guard let cb = self.gameDriverCallbacks else {
-            return
-        }
-        guard let ctx = self.gameDriverCallbackContextPtr else {
-            return
-        }
-        
-        cb.pointee.resize(ctx, UInt32(size.width), UInt32(size.height))
+        self.nativeGameDriver?.resize(size)
     }
 }

--- a/cradle/mac/peridot-cradle/peridot-cradle/peridot-cradle-Bridging-Header.h
+++ b/cradle/mac/peridot-cradle/peridot-cradle/peridot-cradle-Bridging-Header.h
@@ -11,6 +11,16 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    void (*terminate)(void* context_ptr);
+    void (*update)(void* context_ptr);
+    void (*resize)(void* context_ptr, uint32_t w, uint32_t h);
+} GameDriverCallbacks;
+
 typedef struct GameRun_ GameRun;
 
 const uint8_t KEYMOD_SHIFT = 1;
@@ -19,10 +29,7 @@ const uint8_t KEYMOD_CONTROL = 3;
 const uint8_t KEYMOD_COMMAND = 4;
 const uint8_t KEYMOD_CAPSLOCK = 5;
 
-GameRun* launch_game(void* viewptr);
-void terminate_game(GameRun* engineptr);
-void update_game(GameRun* engineptr);
-void resize_game(GameRun* engineptr, uint32_t w, uint32_t h);
+GameRun* launch_game(void* initializationContext, void* viewptr);
 
 void handle_character_keydown(GameRun* engineptr, uint8_t character);
 void handle_character_keyup(GameRun* engineptr, uint8_t character);
@@ -34,5 +41,9 @@ void handle_mouse_button_up(GameRun* engineptr, uint8_t index);
 void report_mouse_move_abs(GameRun* engineptr, float x, float y);
 
 void* captionbar_text();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* peridot_cradle_Bridging_Header_h */

--- a/cradle/mac/peridot-cradle/peridot-cradle/peridot-cradle-Bridging-Header.h
+++ b/cradle/mac/peridot-cradle/peridot-cradle/peridot-cradle-Bridging-Header.h
@@ -19,9 +19,14 @@ typedef struct {
     void (*terminate)(void* context_ptr);
     void (*update)(void* context_ptr);
     void (*resize)(void* context_ptr, uint32_t w, uint32_t h);
+    void (*handle_character_keydown)(void* context_ptr, uint8_t character);
+    void (*handle_character_keyup)(void* context_ptr, uint8_t character);
+    void (*handle_keymod_down)(void* context_ptr, uint8_t code);
+    void (*handle_keymod_up)(void* context_ptr, uint8_t code);
+    void (*handle_mouse_button_down)(void* context_ptr, uint8_t index);
+    void (*handle_mouse_button_up)(void* context_ptr, uint8_t index);
+    void (*report_mouse_move_abs)(void* context_ptr, float x, float y);
 } GameDriverCallbacks;
-
-typedef struct GameRun_ GameRun;
 
 const uint8_t KEYMOD_SHIFT = 1;
 const uint8_t KEYMOD_OPTION = 2;
@@ -29,17 +34,7 @@ const uint8_t KEYMOD_CONTROL = 3;
 const uint8_t KEYMOD_COMMAND = 4;
 const uint8_t KEYMOD_CAPSLOCK = 5;
 
-GameRun* launch_game(void* initializationContext, void* viewptr);
-
-void handle_character_keydown(GameRun* engineptr, uint8_t character);
-void handle_character_keyup(GameRun* engineptr, uint8_t character);
-void handle_keymod_down(GameRun* engineptr, uint8_t code);
-void handle_keymod_up(GameRun* engineptr, uint8_t code);
-
-void handle_mouse_button_down(GameRun* engineptr, uint8_t index);
-void handle_mouse_button_up(GameRun* engineptr, uint8_t index);
-void report_mouse_move_abs(GameRun* engineptr, float x, float y);
-
+void launch_game(void* initializationContext, void* viewptr);
 void* captionbar_text();
 
 #ifdef __cplusplus

--- a/cradle/mac/src/lib.rs
+++ b/cradle/mac/src/lib.rs
@@ -6,10 +6,12 @@ use objc::{msg_send, sel, sel_impl};
 
 use bedrock as br;
 use br::PhysicalDevice;
+use core::future::Future;
 use peridot::mthelper::SharedRef;
 use std::ffi::CStr;
 use std::io::Cursor;
 use std::io::{Error as IOError, ErrorKind, Result as IOResult};
+use std::pin::Pin;
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::{Layer, Registry};
 
@@ -113,10 +115,11 @@ impl PlatformAssetLoader {
     fn new() -> Self {
         let mut pathbase = NSString::from_str("assets").expect("NSString for pathbase");
         let mut pathext = NSString::from_str("par").expect("NSString for ext");
-        let par_path = unsafe {
+        let par_path: CocoaObject<NSString> = unsafe {
             CocoaObject::from_retained_id(nsbundle_path_for_resource(&mut *pathbase, &mut *pathext))
                 .expect("No Primary Asset")
         };
+        println!("par_path: {}", par_path.to_str());
 
         PlatformAssetLoader { par_path }
     }
@@ -321,64 +324,172 @@ impl peridot::NativeLinker for NativeLink {
     }
 }
 mod userlib;
-type Engine = peridot::Engine<NativeLink>;
+type Engine<'q> = peridot::Engine<'q, NativeLink>;
+
+const USERCODE_WAKER_VTABLE: &'static core::task::RawWakerVTable = &core::task::RawWakerVTable::new(
+    |ptr| core::task::RawWaker::new(ptr, USERCODE_WAKER_VTABLE),
+    |_| {},
+    |_| {},
+    |_| {},
+);
 
 pub struct GameDriver {
     ex_input: peridot::InputProcess,
     frame_timing_sender: async_std::channel::Sender<()>,
     event_sender: async_std::channel::Sender<peridot::EngineEvent>,
-    usercode_thread: async_std::task::JoinHandle<()>,
+    event_queue: peridot::EventQueue,
+    _pinned: core::marker::PhantomPinned,
 }
-impl GameDriver {
-    pub fn new(rt_view: *mut libc::c_void) -> Self {
-        let (event_sender, event_receiver) =
-            async_std::channel::unbounded::<peridot::EngineEvent>();
-        let (frame_timing_sender, frame_timing_receiver) = async_std::channel::bounded::<()>(1);
 
-        let nl = NativeLink::new(rt_view);
-        let mut engine = Engine::new(
-            userlib::APP_IDENTIFIER,
-            userlib::APP_VERSION,
-            nl,
-            Default::default(),
-            (event_sender.clone(), event_receiver),
-            frame_timing_receiver,
-        );
-        let nih = Box::new(NativeInputHandler::new(rt_view));
-        engine.input().set_nativelink(nih);
-        let mut nae = NativeAudioEngine::init();
-        nae.start(engine.audio_mixer().clone());
-        engine.post_init();
-        let ex_input = engine.input().clone();
+pub struct AppInternalState {
+    pub event_queue: peridot::EventQueue,
+}
 
-        let usercode_thread = async_std::task::spawn(async move {
-            userlib::game_main(&mut engine).await;
-        });
+fn launch_f<'f, F>(
+    initialization_context: *mut core::ffi::c_void,
+    v: *mut core::ffi::c_void,
+    launch_usercode: impl FnOnce(peridot::Engine<'f, NativeLink>) -> F,
+) -> *mut core::ffi::c_void
+where
+    F: Future<Output = ()> + 'f,
+{
+    let (event_sender, event_receiver) = async_std::channel::unbounded::<peridot::EngineEvent>();
+    let (frame_timing_sender, frame_timing_receiver) = async_std::channel::bounded::<()>(1);
 
-        GameDriver {
-            ex_input,
-            frame_timing_sender,
-            event_sender,
-            usercode_thread,
+    let state = Box::new(AppInternalState {
+        event_queue: peridot::EventQueue::new(),
+    });
+    let state_ptr = Box::into_raw(state);
+    let state_lifetime_extended: &'f AppInternalState = unsafe { &*state_ptr };
+
+    let mut engine = Engine::new(
+        userlib::APP_IDENTIFIER,
+        userlib::APP_VERSION,
+        NativeLink::new(v),
+        Default::default(),
+        (event_sender.clone(), event_receiver),
+        frame_timing_receiver,
+        &state_lifetime_extended.event_queue,
+    );
+    let nih = Box::new(NativeInputHandler::new(v));
+    engine.input().set_nativelink(nih);
+    let mut nae = NativeAudioEngine::init();
+    nae.start(engine.audio_mixer().clone());
+    engine.post_init();
+    let ex_input = engine.input().clone();
+
+    let usercode_waker =
+        unsafe { core::task::Waker::new(core::ptr::null(), &USERCODE_WAKER_VTABLE) };
+    let mut usercode = Box::pin(launch_usercode(engine));
+    let _ = usercode
+        .as_mut()
+        .poll(&mut core::task::Context::from_waker(&usercode_waker));
+
+    struct GameDriverContext<F> {
+        usercode: Pin<Box<F>>,
+        state: Box<AppInternalState>,
+    }
+    extern "C" fn game_driver_terminate<F: core::future::Future>(ctx: *mut core::ffi::c_void) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        ctx.state.event_queue.enqueue(peridot::Event::Shutdown);
+        loop {
+            let usercode_waker =
+                unsafe { core::task::Waker::new(core::ptr::null(), &USERCODE_WAKER_VTABLE) };
+            if ctx
+                .usercode
+                .as_mut()
+                .poll(&mut core::task::Context::from_waker(&usercode_waker))
+                .is_ready()
+            {
+                break;
+            }
+        }
+
+        drop(unsafe { Box::from_raw(ctx) });
+
+        unsafe {
+            nsapp_reply_should_terminate();
         }
     }
+    extern "C" fn game_driver_update<F: core::future::Future>(ctx: *mut core::ffi::c_void) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        ctx.state.event_queue.enqueue(peridot::Event::NextFrame);
+        let usercode_waker =
+            unsafe { core::task::Waker::new(core::ptr::null(), &USERCODE_WAKER_VTABLE) };
+        let _ = ctx
+            .usercode
+            .as_mut()
+            .poll(&mut core::task::Context::from_waker(&usercode_waker));
+    }
+    extern "C" fn game_driver_resize<F: core::future::Future>(
+        ctx: *mut core::ffi::c_void,
+        w: u32,
+        h: u32,
+    ) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        ctx.state
+            .event_queue
+            .enqueue(peridot::Event::Resize(peridot::math::Vector2(w, h)));
+        let usercode_waker =
+            unsafe { core::task::Waker::new(core::ptr::null(), &USERCODE_WAKER_VTABLE) };
+        let _ = ctx
+            .usercode
+            .as_mut()
+            .poll(&mut core::task::Context::from_waker(&usercode_waker));
+    }
+    let cbs: &'static GameDriverCallbacks = &GameDriverCallbacks {
+        terminate: game_driver_terminate::<F>,
+        update: game_driver_update::<F>,
+        resize: game_driver_resize::<F>,
+    };
+    unsafe {
+        give_game_driver_callbacks(
+            initialization_context,
+            cbs,
+            Box::into_raw(Box::new(GameDriverContext {
+                usercode,
+                state: Box::from_raw(state_ptr),
+            })) as _,
+        )
+    }
+
+    core::ptr::null_mut()
 }
 
 // Swift Linking //
 
-extern "C" {
-    fn nsapp_reply_should_terminate();
+#[repr(C)]
+pub struct GameDriverCallbacks {
+    terminate: extern "C" fn(*mut core::ffi::c_void),
+    update: extern "C" fn(*mut core::ffi::c_void),
+    resize: extern "C" fn(*mut core::ffi::c_void, w: u32, h: u32),
+}
+
+unsafe extern "C" {
+    unsafe fn nsapp_reply_should_terminate();
     #[allow(improper_ctypes)]
-    fn nsbundle_path_for_resource(
+    unsafe fn nsbundle_path_for_resource(
         name: *mut NSString,
         oftype: *mut NSString,
     ) -> *mut objc::runtime::Object;
-    fn nsscreen_backing_scale_factor() -> f32;
-    fn obtain_mouse_pointer_position(rt_view: *mut libc::c_void, x: *mut f32, y: *mut f32);
+    unsafe fn nsscreen_backing_scale_factor() -> f32;
+    unsafe fn obtain_mouse_pointer_position(rt_view: *mut libc::c_void, x: *mut f32, y: *mut f32);
+
+    unsafe fn give_game_driver_callbacks(
+        initialization_context: *mut core::ffi::c_void,
+        callbacks: *const GameDriverCallbacks,
+        aux_ptr: *mut core::ffi::c_void,
+    );
 }
 
 #[no_mangle]
-pub extern "C" fn launch_game(v: *mut libc::c_void) -> *mut GameDriver {
+pub extern "C" fn launch_game(
+    initialization_context: *mut core::ffi::c_void,
+    v: *mut core::ffi::c_void,
+) -> *mut core::ffi::c_void {
     log::set_logger(&LOGGER).expect("Failed to set logger");
     log::set_max_level(log::LevelFilter::Trace);
 
@@ -390,48 +501,11 @@ pub extern "C" fn launch_game(v: *mut libc::c_void) -> *mut GameDriver {
     );
     tracing::subscriber::set_global_default(subscriber).expect("Failed to set log subscriber");
 
-    Box::into_raw(Box::new(GameDriver::new(v)))
+    launch_f(initialization_context, v, |mut engine| async move {
+        userlib::game_main(&mut engine).await;
+    })
 }
-#[no_mangle]
-pub extern "C" fn terminate_game(g: *mut GameDriver) {
-    let driver = unsafe { Box::from_raw(g) };
 
-    async_std::task::spawn(async move {
-        if driver
-            .event_sender
-            .send(peridot::EngineEvent::Shutdown)
-            .await
-            .is_ok()
-        {
-            driver.usercode_thread.await;
-        }
-
-        unsafe {
-            nsapp_reply_should_terminate();
-        }
-    });
-}
-#[no_mangle]
-pub extern "C" fn update_game(g: *mut GameDriver) {
-    unsafe {
-        match (*g).frame_timing_sender.try_send(()) {
-            Ok(_) => (),
-            Err(async_std::channel::TrySendError::Full(_)) => (),
-            Err(async_std::channel::TrySendError::Closed(_)) => {
-                warn!("Frame timing channel was closed");
-            }
-        }
-    }
-}
-#[no_mangle]
-pub extern "C" fn resize_game(g: *mut GameDriver, w: u32, h: u32) {
-    unsafe {
-        async_std::task::spawn(
-            (*g).event_sender
-                .send(peridot::EngineEvent::Resize(peridot::math::Vector2(w, h))),
-        );
-    }
-}
 #[no_mangle]
 pub extern "C" fn captionbar_text() -> *mut c_void {
     NSString::from_str(userlib::APP_TITLE)
@@ -441,23 +515,25 @@ pub extern "C" fn captionbar_text() -> *mut c_void {
 
 #[no_mangle]
 pub extern "C" fn handle_character_keydown(g: *mut GameDriver, character: u8) {
-    trace!("Dispatching Character Down Event: {}", character);
-    unsafe {
-        (*g).ex_input.dispatch_button_event(
-            peridot::NativeButtonInput::Character((character as char).to_ascii_uppercase()),
-            true,
-        );
-    }
+    // trace!("Dispatching Character Down Event: {}", character);
+    // unsafe {
+    //     (*g).ex_input.dispatch_button_event(
+    //         peridot::NativeButtonInput::Character((character as char).to_ascii_uppercase()),
+    //         true,
+    //     );
+    // }
+    eprintln!("old function");
 }
 #[no_mangle]
 pub extern "C" fn handle_character_keyup(g: *mut GameDriver, character: u8) {
-    trace!("Dispatching Character Up Event: {}", character);
-    unsafe {
-        (*g).ex_input.dispatch_button_event(
-            peridot::NativeButtonInput::Character((character as char).to_ascii_uppercase()),
-            false,
-        );
-    }
+    // trace!("Dispatching Character Up Event: {}", character);
+    // unsafe {
+    //     (*g).ex_input.dispatch_button_event(
+    //         peridot::NativeButtonInput::Character((character as char).to_ascii_uppercase()),
+    //         false,
+    //     );
+    // }
+    eprintln!("old function");
 }
 
 const KEYMOD_SHIFT: u8 = 1;
@@ -467,33 +543,35 @@ const KEYMOD_COMMAND: u8 = 4;
 const KEYMOD_CAPSLOCK: u8 = 5;
 #[no_mangle]
 pub extern "C" fn handle_keymod_down(g: *mut GameDriver, code: u8) {
-    trace!("Dispatching Keymod Down Event: {}", code);
-    let code_to_bty = match code {
-        KEYMOD_SHIFT => peridot::NativeButtonInput::LeftShift,
-        KEYMOD_OPTION => peridot::NativeButtonInput::LeftAlt,
-        KEYMOD_CONTROL => peridot::NativeButtonInput::LeftControl,
-        KEYMOD_COMMAND => peridot::NativeButtonInput::LeftMeta,
-        KEYMOD_CAPSLOCK => peridot::NativeButtonInput::CapsLock,
-        _ => return,
-    };
-    unsafe {
-        (*g).ex_input.dispatch_button_event(code_to_bty, true);
-    }
+    // trace!("Dispatching Keymod Down Event: {}", code);
+    // let code_to_bty = match code {
+    //     KEYMOD_SHIFT => peridot::NativeButtonInput::LeftShift,
+    //     KEYMOD_OPTION => peridot::NativeButtonInput::LeftAlt,
+    //     KEYMOD_CONTROL => peridot::NativeButtonInput::LeftControl,
+    //     KEYMOD_COMMAND => peridot::NativeButtonInput::LeftMeta,
+    //     KEYMOD_CAPSLOCK => peridot::NativeButtonInput::CapsLock,
+    //     _ => return,
+    // };
+    // unsafe {
+    //     (*g).ex_input.dispatch_button_event(code_to_bty, true);
+    // }
+    eprintln!("old function");
 }
 #[no_mangle]
 pub extern "C" fn handle_keymod_up(g: *mut GameDriver, code: u8) {
-    trace!("Dispatching Keymod Up Event: {}", code);
-    let code_to_bty = match code {
-        KEYMOD_SHIFT => peridot::NativeButtonInput::LeftShift,
-        KEYMOD_OPTION => peridot::NativeButtonInput::LeftAlt,
-        KEYMOD_CONTROL => peridot::NativeButtonInput::LeftControl,
-        KEYMOD_COMMAND => peridot::NativeButtonInput::LeftMeta,
-        KEYMOD_CAPSLOCK => peridot::NativeButtonInput::CapsLock,
-        _ => return,
-    };
-    unsafe {
-        (*g).ex_input.dispatch_button_event(code_to_bty, false);
-    }
+    // trace!("Dispatching Keymod Up Event: {}", code);
+    // let code_to_bty = match code {
+    //     KEYMOD_SHIFT => peridot::NativeButtonInput::LeftShift,
+    //     KEYMOD_OPTION => peridot::NativeButtonInput::LeftAlt,
+    //     KEYMOD_CONTROL => peridot::NativeButtonInput::LeftControl,
+    //     KEYMOD_COMMAND => peridot::NativeButtonInput::LeftMeta,
+    //     KEYMOD_CAPSLOCK => peridot::NativeButtonInput::CapsLock,
+    //     _ => return,
+    // };
+    // unsafe {
+    //     (*g).ex_input.dispatch_button_event(code_to_bty, false);
+    // }
+    eprintln!("old function");
 }
 
 struct NativeInputHandler {
@@ -523,26 +601,29 @@ impl peridot::NativeInput for NativeInputHandler {
 
 #[no_mangle]
 pub extern "C" fn handle_mouse_button_down(g: *mut GameDriver, index: u8) {
-    unsafe {
-        (*g).ex_input
-            .dispatch_button_event(peridot::NativeButtonInput::Mouse(index as _), true);
-    }
+    // unsafe {
+    //     (*g).ex_input
+    //         .dispatch_button_event(peridot::NativeButtonInput::Mouse(index as _), true);
+    // }
+    eprintln!("old function");
 }
 #[no_mangle]
 pub extern "C" fn handle_mouse_button_up(g: *mut GameDriver, index: u8) {
-    unsafe {
-        (*g).ex_input
-            .dispatch_button_event(peridot::NativeButtonInput::Mouse(index as _), false);
-    }
+    // unsafe {
+    //     (*g).ex_input
+    //         .dispatch_button_event(peridot::NativeButtonInput::Mouse(index as _), false);
+    // }
+    eprintln!("old function");
 }
 
 #[no_mangle]
 pub extern "C" fn report_mouse_move_abs(g: *mut GameDriver, x: f32, y: f32) {
-    unsafe {
-        let scale = nsscreen_backing_scale_factor();
-        (*g).ex_input
-            .dispatch_analog_event(peridot::NativeAnalogInput::MouseX, x * scale, true);
-        (*g).ex_input
-            .dispatch_analog_event(peridot::NativeAnalogInput::MouseY, y * scale, true);
-    }
+    // unsafe {
+    //     let scale = nsscreen_backing_scale_factor();
+    //     (*g).ex_input
+    //         .dispatch_analog_event(peridot::NativeAnalogInput::MouseX, x * scale, true);
+    //     (*g).ex_input
+    //         .dispatch_analog_event(peridot::NativeAnalogInput::MouseY, y * scale, true);
+    // }
+    eprintln!("old function");
 }

--- a/cradle/mac/src/lib.rs
+++ b/cradle/mac/src/lib.rs
@@ -328,8 +328,8 @@ type Engine<'q> = peridot::Engine<'q, NativeLink>;
 
 const USERCODE_WAKER_VTABLE: &'static core::task::RawWakerVTable = &core::task::RawWakerVTable::new(
     |ptr| core::task::RawWaker::new(ptr, USERCODE_WAKER_VTABLE),
-    |_| {},
-    |_| {},
+    |_| /*println!("game_main wake")*/{},
+    |_| /*println!("game_main wake by ref")*/{},
     |_| {},
 );
 
@@ -349,8 +349,7 @@ fn launch_f<'f, F>(
     initialization_context: *mut core::ffi::c_void,
     v: *mut core::ffi::c_void,
     launch_usercode: impl FnOnce(peridot::Engine<'f, NativeLink>) -> F,
-) -> *mut core::ffi::c_void
-where
+) where
     F: Future<Output = ()> + 'f,
 {
     let (event_sender, event_receiver) = async_std::channel::unbounded::<peridot::EngineEvent>();
@@ -376,7 +375,7 @@ where
     let mut nae = NativeAudioEngine::init();
     nae.start(engine.audio_mixer().clone());
     engine.post_init();
-    let ex_input = engine.input().clone();
+    let input = engine.input().clone();
 
     let usercode_waker =
         unsafe { core::task::Waker::new(core::ptr::null(), &USERCODE_WAKER_VTABLE) };
@@ -388,6 +387,7 @@ where
     struct GameDriverContext<F> {
         usercode: Pin<Box<F>>,
         state: Box<AppInternalState>,
+        input: peridot::InputProcess,
     }
     extern "C" fn game_driver_terminate<F: core::future::Future>(ctx: *mut core::ffi::c_void) {
         let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
@@ -440,10 +440,102 @@ where
             .as_mut()
             .poll(&mut core::task::Context::from_waker(&usercode_waker));
     }
+    extern "C" fn game_driver_handle_character_keydown<F: core::future::Future>(
+        ctx: *mut core::ffi::c_void,
+        character: u8,
+    ) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        ctx.input.dispatch_button_event(
+            peridot::NativeButtonInput::Character((character as char).to_ascii_uppercase()),
+            true,
+        );
+    }
+    extern "C" fn game_driver_handle_character_keyup<F: core::future::Future>(
+        ctx: *mut core::ffi::c_void,
+        character: u8,
+    ) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        ctx.input.dispatch_button_event(
+            peridot::NativeButtonInput::Character((character as char).to_ascii_uppercase()),
+            false,
+        );
+    }
+    extern "C" fn game_driver_handle_keymod_down<F: core::future::Future>(
+        ctx: *mut core::ffi::c_void,
+        code: u8,
+    ) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        let code_to_bty = match code {
+            KEYMOD_SHIFT => peridot::NativeButtonInput::LeftShift,
+            KEYMOD_OPTION => peridot::NativeButtonInput::LeftAlt,
+            KEYMOD_CONTROL => peridot::NativeButtonInput::LeftControl,
+            KEYMOD_COMMAND => peridot::NativeButtonInput::LeftMeta,
+            KEYMOD_CAPSLOCK => peridot::NativeButtonInput::CapsLock,
+            _ => return,
+        };
+        ctx.input.dispatch_button_event(code_to_bty, true);
+    }
+    extern "C" fn game_driver_handle_keymod_up<F: core::future::Future>(
+        ctx: *mut core::ffi::c_void,
+        code: u8,
+    ) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        let code_to_bty = match code {
+            KEYMOD_SHIFT => peridot::NativeButtonInput::LeftShift,
+            KEYMOD_OPTION => peridot::NativeButtonInput::LeftAlt,
+            KEYMOD_CONTROL => peridot::NativeButtonInput::LeftControl,
+            KEYMOD_COMMAND => peridot::NativeButtonInput::LeftMeta,
+            KEYMOD_CAPSLOCK => peridot::NativeButtonInput::CapsLock,
+            _ => return,
+        };
+        ctx.input.dispatch_button_event(code_to_bty, false);
+    }
+    extern "C" fn game_driver_handle_mouse_button_down<F: core::future::Future>(
+        ctx: *mut core::ffi::c_void,
+        index: u8,
+    ) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        ctx.input
+            .dispatch_button_event(peridot::NativeButtonInput::Mouse(index as _), true);
+    }
+    extern "C" fn game_driver_handle_mouse_button_up<F: core::future::Future>(
+        ctx: *mut core::ffi::c_void,
+        index: u8,
+    ) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        ctx.input
+            .dispatch_button_event(peridot::NativeButtonInput::Mouse(index as _), false);
+    }
+    extern "C" fn game_driver_report_mouse_move_abs<F: core::future::Future>(
+        ctx: *mut core::ffi::c_void,
+        x: f32,
+        y: f32,
+    ) {
+        let ctx = unsafe { &mut *(ctx as *mut GameDriverContext<F>) };
+
+        let scale = unsafe { nsscreen_backing_scale_factor() };
+        ctx.input
+            .dispatch_analog_event(peridot::NativeAnalogInput::MouseX, x * scale, true);
+        ctx.input
+            .dispatch_analog_event(peridot::NativeAnalogInput::MouseY, y * scale, true);
+    }
     let cbs: &'static GameDriverCallbacks = &GameDriverCallbacks {
         terminate: game_driver_terminate::<F>,
         update: game_driver_update::<F>,
         resize: game_driver_resize::<F>,
+        handle_character_keydown: game_driver_handle_character_keydown::<F>,
+        handle_character_keyup: game_driver_handle_character_keyup::<F>,
+        handle_keymod_down: game_driver_handle_keymod_down::<F>,
+        handle_keymod_up: game_driver_handle_keymod_up::<F>,
+        handle_mouse_button_down: game_driver_handle_mouse_button_down::<F>,
+        handle_mouse_button_up: game_driver_handle_mouse_button_up::<F>,
+        report_mouse_move_abs: game_driver_report_mouse_move_abs::<F>,
     };
     unsafe {
         give_game_driver_callbacks(
@@ -452,20 +544,32 @@ where
             Box::into_raw(Box::new(GameDriverContext {
                 usercode,
                 state: Box::from_raw(state_ptr),
+                input,
             })) as _,
         )
     }
-
-    core::ptr::null_mut()
 }
 
 // Swift Linking //
+
+const KEYMOD_SHIFT: u8 = 1;
+const KEYMOD_OPTION: u8 = 2;
+const KEYMOD_CONTROL: u8 = 3;
+const KEYMOD_COMMAND: u8 = 4;
+const KEYMOD_CAPSLOCK: u8 = 5;
 
 #[repr(C)]
 pub struct GameDriverCallbacks {
     terminate: extern "C" fn(*mut core::ffi::c_void),
     update: extern "C" fn(*mut core::ffi::c_void),
     resize: extern "C" fn(*mut core::ffi::c_void, w: u32, h: u32),
+    handle_character_keydown: extern "C" fn(*mut core::ffi::c_void, character: u8),
+    handle_character_keyup: extern "C" fn(*mut core::ffi::c_void, character: u8),
+    handle_keymod_down: extern "C" fn(*mut core::ffi::c_void, code: u8),
+    handle_keymod_up: extern "C" fn(*mut core::ffi::c_void, code: u8),
+    handle_mouse_button_down: extern "C" fn(*mut core::ffi::c_void, index: u8),
+    handle_mouse_button_up: extern "C" fn(*mut core::ffi::c_void, index: u8),
+    report_mouse_move_abs: extern "C" fn(*mut core::ffi::c_void, x: f32, y: f32),
 }
 
 unsafe extern "C" {
@@ -489,7 +593,7 @@ unsafe extern "C" {
 pub extern "C" fn launch_game(
     initialization_context: *mut core::ffi::c_void,
     v: *mut core::ffi::c_void,
-) -> *mut core::ffi::c_void {
+) {
     log::set_logger(&LOGGER).expect("Failed to set logger");
     log::set_max_level(log::LevelFilter::Trace);
 
@@ -503,7 +607,7 @@ pub extern "C" fn launch_game(
 
     launch_f(initialization_context, v, |mut engine| async move {
         userlib::game_main(&mut engine).await;
-    })
+    });
 }
 
 #[no_mangle]
@@ -511,67 +615,6 @@ pub extern "C" fn captionbar_text() -> *mut c_void {
     NSString::from_str(userlib::APP_TITLE)
         .expect("CaptionbarText NSString Allocation")
         .into_id() as *mut _
-}
-
-#[no_mangle]
-pub extern "C" fn handle_character_keydown(g: *mut GameDriver, character: u8) {
-    // trace!("Dispatching Character Down Event: {}", character);
-    // unsafe {
-    //     (*g).ex_input.dispatch_button_event(
-    //         peridot::NativeButtonInput::Character((character as char).to_ascii_uppercase()),
-    //         true,
-    //     );
-    // }
-    eprintln!("old function");
-}
-#[no_mangle]
-pub extern "C" fn handle_character_keyup(g: *mut GameDriver, character: u8) {
-    // trace!("Dispatching Character Up Event: {}", character);
-    // unsafe {
-    //     (*g).ex_input.dispatch_button_event(
-    //         peridot::NativeButtonInput::Character((character as char).to_ascii_uppercase()),
-    //         false,
-    //     );
-    // }
-    eprintln!("old function");
-}
-
-const KEYMOD_SHIFT: u8 = 1;
-const KEYMOD_OPTION: u8 = 2;
-const KEYMOD_CONTROL: u8 = 3;
-const KEYMOD_COMMAND: u8 = 4;
-const KEYMOD_CAPSLOCK: u8 = 5;
-#[no_mangle]
-pub extern "C" fn handle_keymod_down(g: *mut GameDriver, code: u8) {
-    // trace!("Dispatching Keymod Down Event: {}", code);
-    // let code_to_bty = match code {
-    //     KEYMOD_SHIFT => peridot::NativeButtonInput::LeftShift,
-    //     KEYMOD_OPTION => peridot::NativeButtonInput::LeftAlt,
-    //     KEYMOD_CONTROL => peridot::NativeButtonInput::LeftControl,
-    //     KEYMOD_COMMAND => peridot::NativeButtonInput::LeftMeta,
-    //     KEYMOD_CAPSLOCK => peridot::NativeButtonInput::CapsLock,
-    //     _ => return,
-    // };
-    // unsafe {
-    //     (*g).ex_input.dispatch_button_event(code_to_bty, true);
-    // }
-    eprintln!("old function");
-}
-#[no_mangle]
-pub extern "C" fn handle_keymod_up(g: *mut GameDriver, code: u8) {
-    // trace!("Dispatching Keymod Up Event: {}", code);
-    // let code_to_bty = match code {
-    //     KEYMOD_SHIFT => peridot::NativeButtonInput::LeftShift,
-    //     KEYMOD_OPTION => peridot::NativeButtonInput::LeftAlt,
-    //     KEYMOD_CONTROL => peridot::NativeButtonInput::LeftControl,
-    //     KEYMOD_COMMAND => peridot::NativeButtonInput::LeftMeta,
-    //     KEYMOD_CAPSLOCK => peridot::NativeButtonInput::CapsLock,
-    //     _ => return,
-    // };
-    // unsafe {
-    //     (*g).ex_input.dispatch_button_event(code_to_bty, false);
-    // }
-    eprintln!("old function");
 }
 
 struct NativeInputHandler {
@@ -597,33 +640,4 @@ impl peridot::NativeInput for NativeInputHandler {
             None
         }
     }
-}
-
-#[no_mangle]
-pub extern "C" fn handle_mouse_button_down(g: *mut GameDriver, index: u8) {
-    // unsafe {
-    //     (*g).ex_input
-    //         .dispatch_button_event(peridot::NativeButtonInput::Mouse(index as _), true);
-    // }
-    eprintln!("old function");
-}
-#[no_mangle]
-pub extern "C" fn handle_mouse_button_up(g: *mut GameDriver, index: u8) {
-    // unsafe {
-    //     (*g).ex_input
-    //         .dispatch_button_event(peridot::NativeButtonInput::Mouse(index as _), false);
-    // }
-    eprintln!("old function");
-}
-
-#[no_mangle]
-pub extern "C" fn report_mouse_move_abs(g: *mut GameDriver, x: f32, y: f32) {
-    // unsafe {
-    //     let scale = nsscreen_backing_scale_factor();
-    //     (*g).ex_input
-    //         .dispatch_analog_event(peridot::NativeAnalogInput::MouseX, x * scale, true);
-    //     (*g).ex_input
-    //         .dispatch_analog_event(peridot::NativeAnalogInput::MouseY, y * scale, true);
-    // }
-    eprintln!("old function");
 }

--- a/cradle/windows/src/main.rs
+++ b/cradle/windows/src/main.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::mem::MaybeUninit;
 mod audio;
 use audio::NativeAudioEngine;
@@ -82,12 +83,19 @@ impl ThreadsafeWindowOps {
 }
 
 pub struct GameDriver {
-    base: peridot::Engine<NativeLink>,
+    base: peridot::Engine<'static, NativeLink>,
     _snd: NativeAudioEngine,
     current_size: peridot::math::Vector2<u32>,
     ri_handler: self::input::RawInputHandler,
     event_sender: async_std::channel::Sender<peridot::EngineEvent>,
 }
+
+static USERCODE_WAKER_VTABLE: core::task::RawWakerVTable = core::task::RawWakerVTable::new(
+    |ptr| core::task::RawWaker::new(ptr, &USERCODE_WAKER_VTABLE),
+    |_| {},
+    |_| {},
+    |_| {},
+);
 
 #[async_std::main]
 async fn main() {
@@ -163,7 +171,10 @@ async fn main() {
     let (frame_timing_sender, frame_timing_receiver) = async_std::channel::bounded::<()>(1);
     let events_sender_th = events_sender.clone();
 
-    let thread = async_std::task::spawn(async move {
+    let event_queue = core::pin::pin!(peridot::EventQueue::new());
+    let event_queue_lifetime_extended: &'static peridot::EventQueue =
+        unsafe { &*(&*event_queue as *const _) };
+    let mut usercode_thread = core::pin::pin!(async move {
         let nl = NativeLink {
             al: AssetProvider::new(),
             window: w.clone(),
@@ -177,6 +188,7 @@ async fn main() {
             },
             (events_sender_th.clone(), events_receiver),
             frame_timing_receiver,
+            event_queue_lifetime_extended,
         );
         let ri_handler = self::input::RawInputHandler::init();
         base.input_mut()
@@ -199,22 +211,34 @@ async fn main() {
     });
 
     while process_message_all() {
-        match frame_timing_sender.try_send(()) {
-            Ok(_) => (),
-            Err(async_std::channel::TrySendError::Full(_)) => (),
-            Err(async_std::channel::TrySendError::Closed(_)) => {
-                // events bus gone
-                break;
-            }
-        }
+        event_queue.enqueue(peridot::Event::NextFrame);
+
+        let waker = unsafe {
+            core::task::Waker::from_raw(core::task::RawWaker::new(
+                core::ptr::null(),
+                &USERCODE_WAKER_VTABLE,
+            ))
+        };
+        let _ = usercode_thread
+            .as_mut()
+            .poll(&mut core::task::Context::from_waker(&waker));
     }
 
-    if events_sender
-        .send(peridot::EngineEvent::Shutdown)
-        .await
-        .is_ok()
-    {
-        thread.await;
+    event_queue.enqueue(peridot::Event::Shutdown);
+    loop {
+        let waker = unsafe {
+            core::task::Waker::from_raw(core::task::RawWaker::new(
+                core::ptr::null(),
+                &USERCODE_WAKER_VTABLE,
+            ))
+        };
+        if usercode_thread
+            .as_mut()
+            .poll(&mut core::task::Context::from_waker(&waker))
+            .is_ready()
+        {
+            break;
+        }
     }
 }
 

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -482,7 +482,7 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
 
     let mut rot = 0.0f32;
     loop {
-        match e.wait_for_event2().await {
+        match e.next_event().await {
             peridot::Event::Shutdown => break,
             peridot::Event::NextFrame => {
                 let fd = match e.prepare_frame() {

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -481,12 +481,10 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
     bgm.write().play();
 
     let mut rot = 0.0f32;
-    println!("th: {:?}", std::thread::current().id());
     loop {
         match e.wait_for_event2().await {
             peridot::Event::Shutdown => break,
             peridot::Event::NextFrame => {
-                println!("nextFrame th: {:?}", std::thread::current().id());
                 let fd = match e.prepare_frame() {
                     Ok(fd) => fd,
                     Err(peridot::PrepareFrameError::FramebufferOutOfDate) => {

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -22,7 +22,7 @@ use peridot_command_object::{
     StandardMesh,
 };
 
-pub async fn game_main(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
+pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinker>) {
     let screen_size = e
         .back_buffer(0)
         .expect("no back buffers?")
@@ -481,10 +481,12 @@ pub async fn game_main(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
     bgm.write().play();
 
     let mut rot = 0.0f32;
-    while let Some(ev) = e.event_receivers().wait_for_event().await {
-        match ev {
+    println!("th: {:?}", std::thread::current().id());
+    loop {
+        match e.wait_for_event2().await {
             peridot::Event::Shutdown => break,
             peridot::Event::NextFrame => {
+                println!("nextFrame th: {:?}", std::thread::current().id());
                 let fd = match e.prepare_frame() {
                     Ok(fd) => fd,
                     Err(peridot::PrepareFrameError::FramebufferOutOfDate) => {

--- a/examples/tapfx/Cargo.toml
+++ b/examples/tapfx/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-peridot = { path = "../../base", features = ["mt"] }
+peridot = { path = "../../base" }
 bedrock = { git = "https://github.com/Pctg-x8/bedrock", branch = "peridot" }
 peridot-vertex-processing-pack = { path = "../../modules/vertex-processing-pack" }
 peridot-semantic-shader.path = "../../modules/semantic-shader"

--- a/examples/tapfx/src/lib.rs
+++ b/examples/tapfx/src/lib.rs
@@ -37,7 +37,7 @@ fn init_controls(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
         .map(peridot::NativeAnalogInput::TouchMoveY(0), INPUT_PLANE_TOP);
 }
 
-pub async fn game_main(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
+pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinker>) {
     init_controls(e);
 
     let bb_size = e
@@ -398,8 +398,8 @@ pub async fn game_main(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
     }
 
     let mut last_mouse_input = false;
-    while let Some(ev) = e.event_receivers().wait_for_event().await {
-        match ev {
+    loop {
+        match e.next_event().await {
             peridot::Event::NextFrame => {
                 let fd = e.prepare_frame().expect("Failed to prepare frame");
 

--- a/examples/vg-sdf-renderer/Cargo.toml
+++ b/examples/vg-sdf-renderer/Cargo.toml
@@ -13,7 +13,7 @@ use-fontconfig = ["peridot-vg/use-fontconfig"]
 
 [dependencies]
 bedrock = { git = "https://github.com/Pctg-x8/bedrock", branch = "peridot" }
-peridot = { path = "../../base", features = ["derive", "mt"] }
+peridot = { path = "../../base", features = ["derive"] }
 peridot-vg = { path = "../../modules/vg" }
 peridot-vertex-processing-pack = { path = "../../modules/vertex-processing-pack" }
 peridot-command-object = { path = "../../modules/command-object", features = [

--- a/examples/vg-sdf-renderer/src/lib.rs
+++ b/examples/vg-sdf-renderer/src/lib.rs
@@ -725,7 +725,7 @@ impl TwoPassStencilSDFRenderer {
 
 const SDF_SIZE: f32 = 32.0;
 
-pub async fn game_main(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
+pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinker>) {
     let back_buffer_size = e
         .back_buffer(0)
         .expect("no back-buffer?")
@@ -988,8 +988,8 @@ pub async fn game_main(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
             .expect("Failed to record commands");
     }
 
-    while let Some(ev) = e.event_receivers().wait_for_event().await {
-        match ev {
+    loop {
+        match e.next_event().await {
             peridot::Event::Shutdown => break,
             peridot::Event::NextFrame => {
                 let fd = e.prepare_frame().expect("Failed to prepare frame");

--- a/examples/vg/Cargo.toml
+++ b/examples/vg/Cargo.toml
@@ -11,7 +11,7 @@ use-freetype = ["peridot-vg/use-freetype"]
 use-fontconfig = ["peridot-vg/use-fontconfig"]
 
 [dependencies]
-peridot = { path = "../../base", features = ["derive", "mt"] }
+peridot = { path = "../../base", features = ["derive"] }
 bedrock = { git = "https://github.com/Pctg-x8/bedrock", branch = "peridot", features = [
     "VK_EXT_debug_report",
 ] }

--- a/examples/vg/src/lib.rs
+++ b/examples/vg/src/lib.rs
@@ -33,7 +33,7 @@ const unsafe fn as_u8_slice<T>(slice: &[T]) -> &[u8] {
     )
 }
 
-pub async fn game_main(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
+pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinker>) {
     let mut font_provider =
         pvg::DefaultFontProvider::new().expect("FontProvider initialization error");
     let font = font_provider
@@ -516,8 +516,8 @@ pub async fn game_main(e: &mut peridot::Engine<impl peridot::NativeLinker>) {
 
     let target_size = peridot::math::Vector2(screen_size.width as _, screen_size.height as _);
 
-    while let Some(ev) = e.event_receivers().wait_for_event().await {
-        match ev {
+    loop {
+        match e.next_event().await {
             peridot::Event::Shutdown => break,
             peridot::Event::NextFrame => {
                 let fd = e.prepare_frame().expect("Failed to prepare frame");

--- a/modules/vg/src/font/core_text.rs
+++ b/modules/vg/src/font/core_text.rs
@@ -1,11 +1,11 @@
-use appkit::{CTFont, CTFontOrientation, ExternalRc};
+use appkit::{CTFont, CTFontOrientation};
 use euclid::Rect;
 use lyon_path::builder::PathBuilder;
 
 use crate::{Font, GlyphLoadingError};
 
 #[repr(transparent)]
-pub struct CoreTextFont(pub(crate) ExternalRc<CTFont>);
+pub struct CoreTextFont(pub(crate) appkit::CoreRetainedObject<CTFont>);
 impl Font for CoreTextFont {
     type GlyphID = u32;
 

--- a/modules/vg/src/font/provider/core_text.rs
+++ b/modules/vg/src/font/provider/core_text.rs
@@ -22,7 +22,7 @@ impl FontProvider for CoreTextFontProvider {
         properties: &FontProperties,
         size: f32,
     ) -> Result<Self::Font, FontConstructionError> {
-        let traits = appkit::NSMutableDictionary::with_capacity(2).map_err(|_| {
+        let mut traits = appkit::NSMutableDictionary::with_capacity(2).map_err(|_| {
             FontConstructionError::SysAPICallError("NSMutableDictionary::with_capacity")
         })?;
         let weight_num = appkit::NSNumber::from_float(properties.native_weight())
@@ -41,7 +41,7 @@ impl FontProvider for CoreTextFontProvider {
             AsRef::as_ref(unsafe { &*appkit::kCTFontSymbolicTrait }),
             symbolic_traits.as_id(),
         );
-        let attrs = appkit::NSMutableDictionary::with_capacity(2).map_err(|_| {
+        let mut attrs = appkit::NSMutableDictionary::with_capacity(2).map_err(|_| {
             FontConstructionError::SysAPICallError("NSMutableDictionary::with_capacity")
         })?;
         let family_name_nsstr = appkit::NSString::from_str(family_name)

--- a/tools/semantic-shaderbuild/src/main.rs
+++ b/tools/semantic-shaderbuild/src/main.rs
@@ -1237,25 +1237,36 @@ impl<'s> CombinedShaderGenContext<'s> {
         }
 
         // expand header code blocks
-        sink.write_vectored(
-            &self
-                .vertex_shader_header_ordered
-                .iter()
-                .map(|x| {
-                    std::io::IoSlice::new(
-                        x.slice
-                            .strip_prefix('{')
-                            .unwrap_or(x.slice)
-                            .strip_suffix('}')
-                            .unwrap_or(x.slice)
-                            .as_bytes(),
-                    )
-                })
-                .collect::<Vec<_>>(),
-        )?;
+        for x in self.vertex_shader_header_ordered.iter() {
+            sink.write_all(
+                x.slice
+                    .strip_prefix('{')
+                    .unwrap_or(x.slice)
+                    .strip_suffix('}')
+                    .unwrap_or(x.slice)
+                    .as_bytes(),
+            )?;
+        }
+        // なぜかmacだとpipeしたstdinに対するwrite_vectoredがうまく動かない（中途半端なとこでEOF判定される？）
+        // let r = sink.write_vectored(
+        //     &self
+        //         .vertex_shader_header_ordered
+        //         .iter()
+        //         .map(|x| {
+        //             std::io::IoSlice::new(
+        //                 x.slice
+        //                     .strip_prefix('{')
+        //                     .unwrap_or(x.slice)
+        //                     .strip_suffix('}')
+        //                     .unwrap_or(x.slice)
+        //                     .as_bytes(),
+        //             )
+        //         })
+        //         .collect::<Vec<_>>(),
+        // )?;
 
         // expand main code blocks
-        sink.write_all(b"void main() {\n")?;
+        sink.write_all(b"void main() {\n").unwrap();
         sink.write_vectored(
             &self
                 .vertex_shader_main_ordered
@@ -1322,22 +1333,33 @@ impl<'s> CombinedShaderGenContext<'s> {
         }
 
         // expand header code blocks
-        sink.write_vectored(
-            &self
-                .fragment_shader_header_ordered
-                .iter()
-                .map(|x| {
-                    std::io::IoSlice::new(
-                        x.slice
-                            .strip_prefix('{')
-                            .unwrap_or(x.slice)
-                            .strip_suffix('}')
-                            .unwrap_or(x.slice)
-                            .as_bytes(),
-                    )
-                })
-                .collect::<Vec<_>>(),
-        )?;
+        for x in self.fragment_shader_header_ordered.iter() {
+            sink.write_all(
+                x.slice
+                    .strip_prefix('{')
+                    .unwrap_or(x.slice)
+                    .strip_suffix('}')
+                    .unwrap_or(x.slice)
+                    .as_bytes(),
+            )?;
+        }
+        // なぜかmacだとpipeしたstdinに対するwrite_vectoredがうまく動かない（中途半端なとこでEOF判定される？）
+        // sink.write_vectored(
+        //     &self
+        //         .fragment_shader_header_ordered
+        //         .iter()
+        //         .map(|x| {
+        //             std::io::IoSlice::new(
+        //                 x.slice
+        //                     .strip_prefix('{')
+        //                     .unwrap_or(x.slice)
+        //                     .strip_suffix('}')
+        //                     .unwrap_or(x.slice)
+        //                     .as_bytes(),
+        //             )
+        //         })
+        //         .collect::<Vec<_>>(),
+        // )?;
 
         // expand main code blocks
         sink.write_all(b"void main() {\n")?;

--- a/tools/semantic-shaderbuild/src/main.rs
+++ b/tools/semantic-shaderbuild/src/main.rs
@@ -1266,7 +1266,7 @@ impl<'s> CombinedShaderGenContext<'s> {
         // )?;
 
         // expand main code blocks
-        sink.write_all(b"void main() {\n").unwrap();
+        sink.write_all(b"void main() {\n")?;
         sink.write_vectored(
             &self
                 .vertex_shader_main_ordered


### PR DESCRIPTION
メインループを雑にasyncにしたせいで色んなスレッドからメインの処理が呼ばれる形になってしまっていて都合が悪い場合が多いのでシングルスレッドで回す（await前後で実行スレッドが変わらないようにする）