### PR TITLE
アセットメタデータ

### DIFF
--- a/examples/image-plane/assets/images/example.p-meta
+++ b/examples/image-plane/assets/images/example.p-meta
@@ -1,0 +1,1 @@
+peridot.image.uastc-level=fastest

--- a/modules/asset-processing/src/builtin.rs
+++ b/modules/asset-processing/src/builtin.rs
@@ -37,7 +37,7 @@ impl crate::AssetProcessor for ImageAssetProcessor {
     fn process(
         &self,
         source_path: &Path,
-        _metadata: &HashMap<String, String>,
+        _metadata: &HashMap<crate::metadata::Key, String>,
         out_path: &Path,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let img = image::open(source_path).map_err(ImageAssetProcessError::OpenFailed)?;
@@ -110,7 +110,7 @@ impl crate::AssetProcessor for SoundAssetProcessor {
     fn process(
         &self,
         source_path: &Path,
-        _metadata: &HashMap<String, String>,
+        _metadata: &HashMap<crate::metadata::Key, String>,
         out_path: &Path,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // TODO: convert to what?

--- a/modules/asset-processing/src/builtin.rs
+++ b/modules/asset-processing/src/builtin.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     ffi::OsStr,
     path::{Path, PathBuf},
 };
@@ -36,6 +37,7 @@ impl crate::AssetProcessor for ImageAssetProcessor {
     fn process(
         &self,
         source_path: &Path,
+        _metadata: &HashMap<String, String>,
         out_path: &Path,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let img = image::open(source_path).map_err(ImageAssetProcessError::OpenFailed)?;
@@ -108,6 +110,7 @@ impl crate::AssetProcessor for SoundAssetProcessor {
     fn process(
         &self,
         source_path: &Path,
+        _metadata: &HashMap<String, String>,
         out_path: &Path,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // TODO: convert to what?

--- a/modules/asset-processing/src/builtin.rs
+++ b/modules/asset-processing/src/builtin.rs
@@ -37,10 +37,40 @@ impl crate::AssetProcessor for ImageAssetProcessor {
     fn process(
         &self,
         source_path: &Path,
-        _metadata: &HashMap<crate::metadata::Key, String>,
+        metadata: &HashMap<crate::metadata::Key, String>,
         out_path: &Path,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let img = image::open(source_path).map_err(ImageAssetProcessError::OpenFailed)?;
+
+        let uastc_level_flag = metadata
+            .get("peridot.image.uastc-level")
+            .and_then(|x| match x {
+                x if x.eq_ignore_ascii_case("slower") => {
+                    Some(ktx::ffi::KTX_PACK_UASTC_LEVEL_VERYSLOW)
+                }
+                x if x.eq_ignore_ascii_case("slow") => Some(ktx::ffi::KTX_PACK_UASTC_LEVEL_SLOWER),
+                x if x.eq_ignore_ascii_case("default") => {
+                    Some(ktx::ffi::KTX_PACK_UASTC_LEVEL_DEFAULT)
+                }
+                x if x.eq_ignore_ascii_case("fast") => Some(ktx::ffi::KTX_PACK_UASTC_LEVEL_FASTER),
+                x if x.eq_ignore_ascii_case("fastest") => {
+                    Some(ktx::ffi::KTX_PACK_UASTC_LEVEL_FASTEST)
+                }
+                _ => None,
+            })
+            .unwrap_or(ktx::ffi::KTX_PACK_UASTC_LEVEL_DEFAULT);
+        let zstd_level = metadata
+            .get("peridot.image.zstd-level")
+            .and_then(|x| x.parse().ok())
+            .unwrap_or(11);
+        let generate_mipmaps = metadata
+            .get("peridot.image.generate-mipmaps")
+            .and_then(|x| match x {
+                x if x.eq_ignore_ascii_case("true") => Some(true),
+                x if x.eq_ignore_ascii_case("false") => Some(false),
+                _ => None,
+            })
+            .unwrap_or(false);
 
         let mut ktx = ktx::Texture2::new(
             &ktx::ffi::ktxTextureCreateInfo {
@@ -55,7 +85,7 @@ impl crate::AssetProcessor for ImageAssetProcessor {
                 numLayers: 1,
                 numFaces: 1,
                 isArray: false,
-                generateMipmaps: false,
+                generateMipmaps: generate_mipmaps,
             },
             true,
         )
@@ -67,11 +97,11 @@ impl crate::AssetProcessor for ImageAssetProcessor {
         ktx.compress_basis_ex(
             &mut ktx::BasisParams::new()
                 .uastc()
-                .uastc_flags(ktx::ffi::KTX_PACK_UASTC_LEVEL_DEFAULT)
+                .uastc_flags(uastc_level_flag)
                 .uastc_rdo(),
         )
         .map_err(|e| ImageAssetProcessError::Ktx2OperationFailure("compress_basis_ex", e))?;
-        ktx.deflate_zstd(11)
+        ktx.deflate_zstd(zstd_level)
             .map_err(|e| ImageAssetProcessError::Ktx2OperationFailure("deflate_zstd", e))?;
         ktx.write_to_named_file(
             &std::ffi::CString::new(

--- a/modules/asset-processing/src/lib.rs
+++ b/modules/asset-processing/src/lib.rs
@@ -78,6 +78,37 @@ pub fn process(
     }
 
     let metadata_path = source_path.as_ref().with_extension("p-meta");
+    let dest_path = processor.dest_path(source_file_name, dest_dir);
+    if !options.force_rebuild
+        && let (Ok(source_meta), Ok(meta_meta), Ok(dest_meta)) = (
+            source_path.as_ref().metadata().inspect_err(
+                |e| tracing::warn!(reason = ?e, path = ?source_path.as_ref(), "retrieving file metadata failed"),
+            ),
+            metadata_path.metadata().inspect_err(
+                |e| tracing::warn!(reason = ?e, path = ?metadata_path, "retrieving file metadata failed"),
+            ),
+            dest_path.metadata().inspect_err(
+                |e| tracing::warn!(reason = ?e, path = ?dest_path, "retrieving file metadata failed"),
+            ),
+        )
+        && let (Ok(source_modtime), Ok(meta_modtime), Ok(dest_modtime)) = (
+            source_meta.modified().inspect_err(
+                |e| tracing::warn!(reason = ?e, path = ?source_path.as_ref(), "retrieving modified time failed"),
+            ),
+            meta_meta.modified().inspect_err(
+                |e| tracing::warn!(reason = ?e, path = ?metadata_path, "retrieving modified time failed"),
+            ),
+            dest_meta.modified().inspect_err(
+                |e| tracing::warn!(reason = ?e, path = ?dest_path, "retrieving modified time failed"),
+            )
+        )
+        && source_modtime <= dest_modtime
+        && meta_modtime <= dest_modtime
+    {
+        tracing::info!(reason = "modified time", "skip asset");
+        return Some(dest_path);
+    }
+
     let metadata = 'load_metadata: {
         if metadata_path.try_exists().inspect_err(|e| tracing::warn!(reason = ?e, path = ?metadata_path, "querying metadata existential failed")).unwrap_or(false) {
             tracing::trace!(source_path = ?source_path.as_ref(), metadata_path = ?metadata_path, "no metadata exists for this asset");
@@ -95,30 +126,6 @@ pub fn process(
         Some(metadata::Parser::new(&content).filter_map(|x| x.inspect_err(|e| tracing::error!(reason = ?e, path = ?metadata_path, "parsing metadata failed")).ok()).map(|(k, v)| (k, v.to_owned())).collect::<HashMap<_, _>>())
     };
     let metadata = metadata.unwrap_or_else(HashMap::new);
-
-    let dest_path = processor.dest_path(source_file_name, dest_dir);
-    if !options.force_rebuild
-        && let (Ok(x), Ok(y)) = (
-            source_path.as_ref().metadata().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?source_path.as_ref(), "retrieving metadata failed"),
-            ),
-            dest_path.metadata().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?dest_path, "retrieving metadata failed"),
-            ),
-        )
-        && let (Ok(x), Ok(y)) = (
-            x.modified().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?source_path.as_ref(), "retrieving modified date failed"),
-            ),
-            y.modified().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?dest_path, "retrieving modified date failed"),
-            )
-        )
-        && x <= y
-    {
-        tracing::info!(reason = "modified time", "skip asset");
-        return Some(dest_path);
-    }
 
     if let Err(e) = processor.process(source_path.as_ref(), &metadata, &dest_path) {
         tracing::error!(reason = ?e, "Failed to process asset");

--- a/modules/asset-processing/src/lib.rs
+++ b/modules/asset-processing/src/lib.rs
@@ -95,7 +95,8 @@ pub fn process(
             }
         };
         let meta_meta = match metadata_path.metadata() {
-            Ok(x) => x,
+            Ok(x) => Some(x),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
             Err(e) => {
                 tracing::warn!(reason = ?e, path = ?metadata_path, "retrieving file metadata failed");
                 // cannot determine(force rebuild)
@@ -119,7 +120,7 @@ pub fn process(
                 break 'determine_rebuild;
             }
         };
-        let meta_modtime = match meta_meta.modified() {
+        let meta_modtime = match meta_meta.map(|x| x.modified()).transpose() {
             Ok(x) => x,
             Err(e) => {
                 tracing::warn!(reason = ?e, path = ?metadata_path, "retrieving modified time failed");
@@ -136,7 +137,7 @@ pub fn process(
             }
         };
 
-        if source_modtime <= dest_modtime && meta_modtime <= dest_modtime {
+        if source_modtime <= dest_modtime && meta_modtime.is_some_and(|x| x <= dest_modtime) {
             tracing::info!(reason = "modified time", "skip asset");
             return Some(dest_path);
         }

--- a/modules/asset-processing/src/lib.rs
+++ b/modules/asset-processing/src/lib.rs
@@ -79,34 +79,67 @@ pub fn process(
 
     let metadata_path = source_path.as_ref().with_extension("p-meta");
     let dest_path = processor.dest_path(source_file_name, dest_dir);
-    if !options.force_rebuild
-        && let (Ok(source_meta), Ok(meta_meta), Ok(dest_meta)) = (
-            source_path.as_ref().metadata().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?source_path.as_ref(), "retrieving file metadata failed"),
-            ),
-            metadata_path.metadata().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?metadata_path, "retrieving file metadata failed"),
-            ),
-            dest_path.metadata().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?dest_path, "retrieving file metadata failed"),
-            ),
-        )
-        && let (Ok(source_modtime), Ok(meta_modtime), Ok(dest_modtime)) = (
-            source_meta.modified().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?source_path.as_ref(), "retrieving modified time failed"),
-            ),
-            meta_meta.modified().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?metadata_path, "retrieving modified time failed"),
-            ),
-            dest_meta.modified().inspect_err(
-                |e| tracing::warn!(reason = ?e, path = ?dest_path, "retrieving modified time failed"),
-            )
-        )
-        && source_modtime <= dest_modtime
-        && meta_modtime <= dest_modtime
-    {
-        tracing::info!(reason = "modified time", "skip asset");
-        return Some(dest_path);
+
+    'determine_rebuild: {
+        if options.force_rebuild {
+            // forced
+            break 'determine_rebuild;
+        }
+
+        let source_meta = match source_path.as_ref().metadata() {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::warn!(reason = ?e, path = ?source_path.as_ref(), "retrieving file metadata failed");
+                // cannot determine(force rebuild)
+                break 'determine_rebuild;
+            }
+        };
+        let meta_meta = match metadata_path.metadata() {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::warn!(reason = ?e, path = ?metadata_path, "retrieving file metadata failed");
+                // cannot determine(force rebuild)
+                break 'determine_rebuild;
+            }
+        };
+        let dest_meta = match dest_path.metadata() {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::warn!(reason = ?e, path = ?dest_path, "retrieving file metadata failed");
+                // cannot determine(force rebuild)
+                break 'determine_rebuild;
+            }
+        };
+
+        let source_modtime = match source_meta.modified() {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::warn!(reason = ?e, path = ?source_path.as_ref(), "retrieving modified time failed");
+                // cannot determine(force rebuild)
+                break 'determine_rebuild;
+            }
+        };
+        let meta_modtime = match meta_meta.modified() {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::warn!(reason = ?e, path = ?metadata_path, "retrieving modified time failed");
+                // cannot determine(force rebuild)
+                break 'determine_rebuild;
+            }
+        };
+        let dest_modtime = match dest_meta.modified() {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::warn!(reason = ?e, path = ?dest_path, "retrieving modified time failed");
+                // cannot determine(force rebuild)
+                break 'determine_rebuild;
+            }
+        };
+
+        if source_modtime <= dest_modtime && meta_modtime <= dest_modtime {
+            tracing::info!(reason = "modified time", "skip asset");
+            return Some(dest_path);
+        }
     }
 
     let metadata = 'load_metadata: {

--- a/modules/asset-processing/src/lib.rs
+++ b/modules/asset-processing/src/lib.rs
@@ -21,7 +21,7 @@ pub trait AssetProcessor {
     fn process(
         &self,
         source_path: &Path,
-        metadata: &HashMap<String, String>,
+        metadata: &HashMap<metadata::Key, String>,
         out_path: &Path,
     ) -> Result<(), Box<dyn std::error::Error>>;
 }

--- a/modules/asset-processing/src/lib.rs
+++ b/modules/asset-processing/src/lib.rs
@@ -143,9 +143,16 @@ pub fn process(
     }
 
     let metadata = 'load_metadata: {
-        if metadata_path.try_exists().inspect_err(|e| tracing::warn!(reason = ?e, path = ?metadata_path, "querying metadata existential failed")).unwrap_or(false) {
-            tracing::trace!(source_path = ?source_path.as_ref(), metadata_path = ?metadata_path, "no metadata exists for this asset");
-            break 'load_metadata None;
+        match metadata_path.try_exists() {
+            Ok(true) => (),
+            Ok(false) => {
+                tracing::trace!(source_path = ?source_path.as_ref(), metadata_path = ?metadata_path, "no metadata exists for this asset");
+                break 'load_metadata None;
+            }
+            Err(e) => {
+                tracing::warn!(reason = ?e, path = ?metadata_path, "querying metadata existential failed");
+                break 'load_metadata None;
+            }
         }
 
         let content = match std::fs::read_to_string(&metadata_path) {
@@ -156,7 +163,16 @@ pub fn process(
             }
         };
 
-        Some(metadata::Parser::new(&content).filter_map(|x| x.inspect_err(|e| tracing::error!(reason = ?e, path = ?metadata_path, "parsing metadata failed")).ok()).map(|(k, v)| (k, v.to_owned())).collect::<HashMap<_, _>>())
+        Some(
+            metadata::Parser::new(&content)
+                .filter_map(
+                    |x| x
+                        .inspect_err(|e| tracing::error!(reason = ?e, path = ?metadata_path, "parsing metadata failed"))
+                        .ok()
+                )
+                .map(|(k, v)| (k, v.to_owned()))
+                .collect::<HashMap<_, _>>()
+        )
     };
     let metadata = metadata.unwrap_or_else(HashMap::new);
 

--- a/modules/asset-processing/src/lib.rs
+++ b/modules/asset-processing/src/lib.rs
@@ -1,9 +1,11 @@
 use std::{
+    collections::HashMap,
     ffi::OsStr,
     path::{Path, PathBuf},
 };
 
 pub mod builtin;
+pub mod metadata;
 
 /// An asset processor interface.
 pub trait AssetProcessor {
@@ -19,6 +21,7 @@ pub trait AssetProcessor {
     fn process(
         &self,
         source_path: &Path,
+        metadata: &HashMap<String, String>,
         out_path: &Path,
     ) -> Result<(), Box<dyn std::error::Error>>;
 }
@@ -74,6 +77,25 @@ pub fn process(
         return None;
     }
 
+    let metadata_path = source_path.as_ref().with_extension("p-meta");
+    let metadata = 'load_metadata: {
+        if metadata_path.try_exists().inspect_err(|e| tracing::warn!(reason = ?e, path = ?metadata_path, "querying metadata existential failed")).unwrap_or(false) {
+            tracing::trace!(source_path = ?source_path.as_ref(), metadata_path = ?metadata_path, "no metadata exists for this asset");
+            break 'load_metadata None;
+        }
+
+        let content = match std::fs::read_to_string(&metadata_path) {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::error!(reason = ?e, path = ?metadata_path, "reading metadata content failed");
+                break 'load_metadata None;
+            }
+        };
+
+        Some(metadata::Parser::new(&content).filter_map(|x| x.inspect_err(|e| tracing::error!(reason = ?e, path = ?metadata_path, "parsing metadata failed")).ok()).map(|(k, v)| (k, v.to_owned())).collect::<HashMap<_, _>>())
+    };
+    let metadata = metadata.unwrap_or_else(HashMap::new);
+
     let dest_path = processor.dest_path(source_file_name, dest_dir);
     if !options.force_rebuild
         && let (Ok(x), Ok(y)) = (
@@ -98,7 +120,7 @@ pub fn process(
         return Some(dest_path);
     }
 
-    if let Err(e) = processor.process(source_path.as_ref(), &dest_path) {
+    if let Err(e) = processor.process(source_path.as_ref(), &metadata, &dest_path) {
         tracing::error!(reason = ?e, "Failed to process asset");
         return None;
     }

--- a/modules/asset-processing/src/metadata.rs
+++ b/modules/asset-processing/src/metadata.rs
@@ -1,0 +1,127 @@
+use std::{ops::Range, str::Chars};
+
+#[derive(Clone, Copy)]
+enum ParserState {
+    Key,
+    Value,
+    Finished,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("no key(at line {line})")]
+    NoKey { line: usize },
+}
+
+pub struct Parser<'s> {
+    content: &'s str,
+    content_chars: Chars<'s>,
+    state: ParserState,
+    key_buffer: String,
+    pointer_bytes: usize,
+    pointer_line: usize,
+    value_byte_range: Range<usize>,
+}
+impl<'s> Parser<'s> {
+    pub fn new(content: &'s str) -> Self {
+        Self {
+            content,
+            content_chars: content.chars(),
+            state: ParserState::Key,
+            key_buffer: String::new(),
+            pointer_bytes: 0,
+            pointer_line: 1,
+            value_byte_range: 0..0,
+        }
+    }
+}
+impl<'s> Iterator for Parser<'s> {
+    type Item = Result<(String, &'s str), ParseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.state {
+            ParserState::Finished => None,
+            ParserState::Key => match self.content_chars.next() {
+                Some(c @ '=') => {
+                    self.pointer_bytes += c.len_utf8();
+                    self.state = ParserState::Value;
+                    self.value_byte_range = self.pointer_bytes..self.pointer_bytes;
+
+                    self.next()
+                }
+                Some(c @ '\n') if self.key_buffer.is_empty() => {
+                    // empty line
+                    self.pointer_bytes += c.len_utf8();
+                    self.pointer_line += 1;
+                    self.state = ParserState::Value;
+
+                    self.next()
+                }
+                Some(c @ '\n') => {
+                    // recover to next line
+                    self.pointer_bytes += c.len_utf8();
+                    self.pointer_line += 1;
+                    self.state = ParserState::Key;
+                    self.key_buffer.clear();
+
+                    Some(Err(ParseError::NoKey {
+                        line: self.pointer_line,
+                    }))
+                }
+                Some(c) => {
+                    self.pointer_bytes += c.len_utf8();
+                    self.key_buffer.push(c);
+
+                    self.next()
+                }
+                None if self.key_buffer.is_empty() => {
+                    // empty final line
+                    self.state = ParserState::Finished;
+
+                    None
+                }
+                None => {
+                    self.state = ParserState::Finished;
+
+                    Some(Err(ParseError::NoKey {
+                        line: self.pointer_line,
+                    }))
+                }
+            },
+            ParserState::Value => match self.content_chars.next() {
+                Some(c @ '\n') => {
+                    self.pointer_bytes += c.len_utf8();
+                    self.pointer_line += 1;
+                    self.state = ParserState::Value;
+
+                    let new_buffer_cap = self.key_buffer.capacity();
+                    let key = core::mem::replace(
+                        &mut self.key_buffer,
+                        String::with_capacity(new_buffer_cap),
+                    );
+                    let value = &self.content[self.value_byte_range.clone()];
+
+                    Some(Ok((key, value)))
+                }
+                Some(c) => {
+                    self.pointer_bytes += c.len_utf8();
+                    self.value_byte_range.end += c.len_utf8();
+
+                    self.next()
+                }
+                None => {
+                    self.state = ParserState::Finished;
+
+                    let new_buffer_cap = self.key_buffer.capacity();
+                    let key = core::mem::replace(
+                        &mut self.key_buffer,
+                        String::with_capacity(new_buffer_cap),
+                    );
+                    let value = &self.content[self.value_byte_range.clone()];
+
+                    Some(Ok((key, value)))
+                }
+            },
+        }
+    }
+}

--- a/modules/asset-processing/src/metadata.rs
+++ b/modules/asset-processing/src/metadata.rs
@@ -92,7 +92,7 @@ impl<'s> Iterator for Parser<'s> {
                 Some(c @ '\n') => {
                     self.pointer_bytes += c.len_utf8();
                     self.pointer_line += 1;
-                    self.state = ParserState::Value;
+                    self.state = ParserState::Key;
 
                     let new_buffer_cap = self.key_buffer.capacity();
                     let key = Key::from_raw_parsed(core::mem::replace(

--- a/modules/asset-processing/src/metadata.rs
+++ b/modules/asset-processing/src/metadata.rs
@@ -36,7 +36,7 @@ impl<'s> Parser<'s> {
     }
 }
 impl<'s> Iterator for Parser<'s> {
-    type Item = Result<(String, &'s str), ParseError>;
+    type Item = Result<(Key, &'s str), ParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.state {
@@ -95,10 +95,10 @@ impl<'s> Iterator for Parser<'s> {
                     self.state = ParserState::Value;
 
                     let new_buffer_cap = self.key_buffer.capacity();
-                    let key = core::mem::replace(
+                    let key = Key::from_raw_parsed(core::mem::replace(
                         &mut self.key_buffer,
                         String::with_capacity(new_buffer_cap),
-                    );
+                    ));
                     let value = &self.content[self.value_byte_range.clone()];
 
                     Some(Ok((key, value)))
@@ -113,15 +113,43 @@ impl<'s> Iterator for Parser<'s> {
                     self.state = ParserState::Finished;
 
                     let new_buffer_cap = self.key_buffer.capacity();
-                    let key = core::mem::replace(
+                    let key = Key::from_raw_parsed(core::mem::replace(
                         &mut self.key_buffer,
                         String::with_capacity(new_buffer_cap),
-                    );
+                    ));
                     let value = &self.content[self.value_byte_range.clone()];
 
                     Some(Ok((key, value)))
                 }
             },
         }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Key(String);
+impl Key {
+    fn from_raw_parsed(mut key: String) -> Self {
+        // truncate ending whitespaces
+        key.truncate(key.trim_ascii_end().len());
+        // case insensitive
+        key.make_ascii_lowercase();
+
+        Self(key)
+    }
+}
+impl core::ops::Deref for Key {
+    type Target = str;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+impl core::borrow::Borrow<str> for Key {
+    #[inline(always)]
+    fn borrow(&self) -> &str {
+        &self.0
     }
 }

--- a/modules/rendering-configuration/src/lib.rs
+++ b/modules/rendering-configuration/src/lib.rs
@@ -79,6 +79,7 @@ impl peridot_asset_processing::AssetProcessor for AssetProcessor {
     fn process(
         &self,
         source_path: &Path,
+        _metadata: &HashMap<peridot_asset_processing::metadata::Key, String>,
         out_path: &Path,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let content =


### PR DESCRIPTION
アセットの前処理などに必要なデータを格納する場所
一旦ファイル名とおなじで拡張子が`p-meta`のファイルをメタデータとする(Unityと同じ仕様)

ただ、これファイル移動にすごい弱いのであとで考えなおすかも(1ファイルに両方まとめられると理想なんだけど、メタデータのいじりやすさをかんがえるとむずかしい

## フォーマット

`key=value`の行がつづくテキストファイル
keyは=以外の文字をすべて含めることができる ただし末尾の空白文字は消される
keyは大小文字区別されない
valueには=を含めることができる(厳密には、行で最初にでた=から改行までのすべての文字が含まれる)