### PR TITLE
Rendering Configurationの構造変更

### DIFF
--- a/.github/workflows/generator/app/IntegrityTest/Shared.hs
+++ b/.github/workflows/generator/app/IntegrityTest/Shared.hs
@@ -196,6 +196,7 @@ cdepsEnvVars variant =
   GHA.env "PERIDOT_BUILD_TP_SLANG_SKIP_CMAKE" "1"
     . GHA.env "PERIDOT_BUILD_TP_KTX_SKIP_CMAKE" "1"
     . GHA.env "PERIDOT_BUILD_TP_SLANG_LIB_PATH" slangLibPath
+    . GHA.env "PERIDOT_BUILD_TP_SPIRV_TOOLS_SKIP_CMAKE" "1"
   where
     -- CIではDebugでビルドしてるのでそれを指定（ただしWindows以外ではなぜかRelease以下に生成される）
     slangLibPath = case variant of

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "thirdparty/slang/source-repo"]
 	path = thirdparty/slang/source-repo
 	url = https://github.com/shader-slang/slang
+[submodule "thirdparty/spirv-tools/source-repo"]
+	path = thirdparty/spirv-tools/source-repo
+	url = https://github.com/KhronosGroup/SPIRV-Tools

--- a/builtin-assets/rendering_configuration/unlit_image.prc
+++ b/builtin-assets/rendering_configuration/unlit_image.prc
@@ -4,10 +4,6 @@ End
 
 Pass "Unlit"
   RenderOption NoCulling
-  VertexBindings
-    pos: Float4 [POSITION0]
-    uv: Float4 [TEXCOORD0]
-  End
 
   Shader
 struct VertexOutput {
@@ -20,11 +16,15 @@ struct FragmentInput {
 }
 
 [shader("vertex")]
-VertexOutput vertMain(Vertex v, Peridot::VertexShaderContext ctx) {
+VertexOutput vertMain(
+    [Peridot::VertexInput] float4 pos : POSITION0,
+    [Peridot::VertexInput] float4 uv : TEXCOORD0,
+    Peridot::VertexShaderContext ctx
+) {
     VertexOutput vo;
 
-    vo.pos = ctx.worldToClipSpace(v.pos);
-    vo.fragmentInput.uv = v.uv.xy;
+    vo.pos = ctx.worldToClipSpace(pos);
+    vo.fragmentInput.uv = uv.xy;
 
     return vo;
 }

--- a/builtin-assets/rendering_configuration/unlit_image.prc
+++ b/builtin-assets/rendering_configuration/unlit_image.prc
@@ -20,18 +20,18 @@ struct FragmentInput {
 }
 
 [shader("vertex")]
-VertexOutput vertMain(Vertex v) {
+VertexOutput vertMain(Vertex v, Peridot::VertexShaderContext ctx) {
     VertexOutput vo;
 
-    vo.pos = mul(PeridotCameraParameters::viewProjectionMatrix(), mul(PeridotObjectParameters::transformMatrix(), v.pos));
+    vo.pos = ctx.worldToClipSpace(v.pos);
     vo.fragmentInput.uv = v.uv.xy;
 
     return vo;
 }
 
 [shader("fragment")]
-float4 fragMain(FragmentInput input : Varyings) : SV_Target {
-    return PeridotMaterialParameters::tex.Sample(input.uv);
+float4 fragMain(FragmentInput input : Varyings, Peridot::FragmentShaderContext ctx) : SV_Target {
+    return ctx.properties.tex.Sample(input.uv);
 }
   End
 End

--- a/builtin-assets/rendering_configuration/unlit_image.prc
+++ b/builtin-assets/rendering_configuration/unlit_image.prc
@@ -23,7 +23,7 @@ VertexOutput vertMain(
 ) {
     VertexOutput vo;
 
-    vo.pos = ctx.worldToClipSpace(pos);
+    vo.pos = ctx.objectToClipSpace(pos);
     vo.fragmentInput.uv = uv.xy;
 
     return vo;

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -432,26 +432,8 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
     )
     .expect("Create DescriptorPool");
 
-    let pl = br::PipelineLayoutObject::new(
-        e.graphics().device().clone(),
-        &br::PipelineLayoutCreateInfo::new(
-            &[
-                dsl_ub1.as_transparent_ref(),
-                dsl_ub1.as_transparent_ref(),
-                dsl_rc.as_transparent_ref(),
-            ],
-            &if rc.push_constant_buffer_size_bytes > 0 {
-                vec![br::PushConstantRange::new(
-                    br::vk::VK_SHADER_STAGE_ALL,
-                    0..rc.push_constant_buffer_size_bytes as _,
-                )]
-            } else {
-                vec![]
-            },
-        ),
-    )
-    .expect("Create PipelineLayout");
-    let [gp] = match rc.passes["Unlit"] {
+    let (pl, gp);
+    match rc.passes["Unlit"] {
         prc::ShadingPassVk::SimpleDeriveBuiltinPass { ref name } => {
             todo!("using builtin pass: {name}");
         }
@@ -460,11 +442,33 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
             ref variants,
         } => {
             let prc::Code {
+                push_constant_buffer_size_bytes,
                 ref words,
                 ref vertex_entry_point_name,
                 ref fragment_entry_point_name,
                 ref vertex_semantic_to_location,
             } = variants[&prc::VariantKey { instancing: false }];
+
+            pl = br::PipelineLayoutObject::new(
+                e.graphics().device().clone(),
+                &br::PipelineLayoutCreateInfo::new(
+                    &[
+                        dsl_ub1.as_transparent_ref(),
+                        dsl_ub1.as_transparent_ref(),
+                        dsl_rc.as_transparent_ref(),
+                    ],
+                    &if push_constant_buffer_size_bytes > 0 {
+                        vec![br::PushConstantRange::new(
+                            br::vk::VK_SHADER_STAGE_ALL,
+                            0..push_constant_buffer_size_bytes as _,
+                        )]
+                    } else {
+                        vec![]
+                    },
+                ),
+            )
+            .expect("Create PipelineLayout");
+
             let sc = [br::Extent2D::from(screen_size).into_rect(br::Offset2D::ZERO)];
             let vp = [sc[0].make_viewport(0.0..1.0)];
 
@@ -488,7 +492,8 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
             }
 
             // TODO: このへんのパラメータもRendering Configurationで指定できるようにする
-            e.graphics()
+            let [gp1] = e
+                .graphics()
                 .device()
                 .new_graphics_pipeline_array(
                     &[br::GraphicsPipelineCreateInfo::new(
@@ -547,7 +552,8 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
                     .set_multisample_state(&br::PipelineMultisampleStateCreateInfo::new())],
                     None::<&br::PipelineCacheObject<peridot::DeviceObject>>,
                 )
-                .expect("Create GraphicsPipeline")
+                .expect("Create GraphicsPipeline");
+            gp = gp1;
         }
     };
     let gp = gp.clone_parent();

--- a/examples/image-plane/src/lib.rs
+++ b/examples/image-plane/src/lib.rs
@@ -372,30 +372,6 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
         .load_async("builtin.rendering_configuration.unlit_image")
         .await
         .expect("Loading rendering configuration");
-    let dsl_rc = br::DescriptorSetLayoutObject::new(
-        e.graphics().device().clone(),
-        &br::DescriptorSetLayoutCreateInfo::new(
-            &rc.descriptor_set_bindings
-                .iter()
-                .enumerate()
-                .map(|(n, x)| match x {
-                    prc::DescriptorTypeVk::CombinedImageSampler => {
-                        // TODO: immutable sampler or dynamic sampler selection in rendering configuration
-                        br::DescriptorType::CombinedImageSampler
-                            .make_binding(n as _, 1)
-                            .with_immutable_samplers(&single_smp_refs)
-                    }
-                    prc::DescriptorTypeVk::UniformBuffer { .. } => {
-                        br::DescriptorType::UniformBuffer.make_binding(n as _, 1)
-                    }
-                    prc::DescriptorTypeVk::StorageBuffer { .. } => {
-                        br::DescriptorType::StorageBuffer.make_binding(n as _, 1)
-                    }
-                })
-                .collect::<Vec<_>>(),
-        ),
-    )
-    .expect("Create DescriptorSetLayout for Material");
     let dsl_ub1 = br::DescriptorSetLayoutObject::new(
         e.graphics().device().clone(),
         &br::DescriptorSetLayoutCreateInfo::new(&[br::DescriptorType::UniformBuffer
@@ -406,33 +382,8 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
     let mut descriptor_uniform_counts = 2; // camera+object
     let mut descriptor_sampler_counts = 0;
     let mut descriptor_storage_counts = 0;
-    for x in rc.descriptor_set_bindings.iter() {
-        match x {
-            prc::DescriptorTypeVk::CombinedImageSampler => {
-                descriptor_sampler_counts += 1;
-            }
-            prc::DescriptorTypeVk::UniformBuffer { .. } => {
-                descriptor_uniform_counts += 1;
-            }
-            prc::DescriptorTypeVk::StorageBuffer { .. } => {
-                descriptor_storage_counts += 1;
-            }
-        }
-    }
-    let mut descriptor_pool = br::DescriptorPoolObject::new(
-        e.graphics().device().clone(),
-        &br::DescriptorPoolCreateInfo::new(
-            3,
-            &[
-                br::DescriptorType::UniformBuffer.make_size(descriptor_uniform_counts),
-                br::DescriptorType::StorageBuffer.make_size(descriptor_storage_counts),
-                br::DescriptorType::CombinedImageSampler.make_size(descriptor_sampler_counts),
-            ],
-        ),
-    )
-    .expect("Create DescriptorPool");
 
-    let (pl, gp);
+    let (dsl_rc, pl, gp);
     match rc.passes["Unlit"] {
         prc::ShadingPassVk::SimpleDeriveBuiltinPass { ref name } => {
             todo!("using builtin pass: {name}");
@@ -443,11 +394,50 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
         } => {
             let prc::Code {
                 push_constant_buffer_size_bytes,
+                ref descriptor_set_bindings,
                 ref words,
                 ref vertex_entry_point_name,
                 ref fragment_entry_point_name,
                 ref vertex_semantic_to_location,
             } = variants[&prc::VariantKey { instancing: false }];
+
+            dsl_rc = br::DescriptorSetLayoutObject::new(
+                e.graphics().device().clone(),
+                &br::DescriptorSetLayoutCreateInfo::new(
+                    &descriptor_set_bindings
+                        .iter()
+                        .enumerate()
+                        .map(|(n, x)| match x {
+                            prc::DescriptorTypeVk::CombinedImageSampler => {
+                                // TODO: immutable sampler or dynamic sampler selection in rendering configuration
+                                br::DescriptorType::CombinedImageSampler
+                                    .make_binding(n as _, 1)
+                                    .with_immutable_samplers(&single_smp_refs)
+                            }
+                            prc::DescriptorTypeVk::UniformBuffer { .. } => {
+                                br::DescriptorType::UniformBuffer.make_binding(n as _, 1)
+                            }
+                            prc::DescriptorTypeVk::StorageBuffer { .. } => {
+                                br::DescriptorType::StorageBuffer.make_binding(n as _, 1)
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                ),
+            )
+            .expect("Create DescriptorSetLayout for Material");
+            for x in descriptor_set_bindings.iter() {
+                match x {
+                    prc::DescriptorTypeVk::CombinedImageSampler => {
+                        descriptor_sampler_counts += 1;
+                    }
+                    prc::DescriptorTypeVk::UniformBuffer { .. } => {
+                        descriptor_uniform_counts += 1;
+                    }
+                    prc::DescriptorTypeVk::StorageBuffer { .. } => {
+                        descriptor_storage_counts += 1;
+                    }
+                }
+            }
 
             pl = br::PipelineLayoutObject::new(
                 e.graphics().device().clone(),
@@ -561,6 +551,19 @@ pub async fn game_main<'q>(e: &mut peridot::Engine<'q, impl peridot::NativeLinke
     e.graphics_device()
         .set_object_name(&gp, c"Main Pipeline")
         .expect("Failed to set pipeline name");
+
+    let mut descriptor_pool = br::DescriptorPoolObject::new(
+        e.graphics().device().clone(),
+        &br::DescriptorPoolCreateInfo::new(
+            3,
+            &[
+                br::DescriptorType::UniformBuffer.make_size(descriptor_uniform_counts),
+                br::DescriptorType::StorageBuffer.make_size(descriptor_storage_counts),
+                br::DescriptorType::CombinedImageSampler.make_size(descriptor_sampler_counts),
+            ],
+        ),
+    )
+    .expect("Create DescriptorPool");
 
     pre_configure_awaiter
         .await

--- a/examples/sprite-atlas/assets/shaders/unlit_image_atlas.prc
+++ b/examples/sprite-atlas/assets/shaders/unlit_image_atlas.prc
@@ -5,12 +5,14 @@ End
 
 Pass "Unlit"
     RenderOption NoCulling, InstancedOnly
-    VertexBindings
-        pos: Float4 [POSITION0]
-        uv: Float4 [TEXCOORD0]
-    End
 
     Shader
+[Peridot::VertexInput]
+struct Vertex {
+    float4 pos : POSITION0;
+    float2 uv : TEXCOORD0;
+}
+
 struct VertexOutput {
     FragmentInput fragmentInput : Varyings;
     float4 pos : SV_Position;
@@ -33,7 +35,7 @@ VertexOutput vertMain(Vertex v, Peridot::VertexShaderContext ctx) {
 [shader("fragment")]
 float4 fragMain(FragmentInput input : Varyings, Peridot::FragmentShaderContext ctx) : SV_Target {
     // return float4(input.uv, 1.0, 1.0);
-    float4 col = ctx.properties.maintex.Sample(input.uv);
+    var col = ctx.properties.maintex.Sample(input.uv);
     col.rgb *= col.a;
     return col;
 }

--- a/examples/sprite-atlas/assets/shaders/unlit_image_atlas.prc
+++ b/examples/sprite-atlas/assets/shaders/unlit_image_atlas.prc
@@ -21,19 +21,19 @@ struct FragmentInput {
 }
 
 [shader("vertex")]
-VertexOutput vertMain(Vertex v) {
+VertexOutput vertMain(Vertex v, Peridot::VertexShaderContext ctx) {
     VertexOutput vo;
 
-    vo.pos = mul(PeridotCameraParameters::viewProjectionMatrix(), mul(PeridotObjectParameters::transformMatrix(PERIDOT_OBJECT_PARAMETERS_ARGS(v)), v.pos));
-    vo.fragmentInput.uv = v.uv.xy * PeridotMaterialParameters::instancedProperty[v.__peridot_instanceVars.instanceIndex].maintex_uvst.xy + PeridotMaterialParameters::instancedProperty[v.__peridot_instanceVars.instanceIndex].maintex_uvst.zw;
+    vo.pos = ctx.worldToClipSpace(v.pos);
+    vo.fragmentInput.uv = v.uv.xy * ctx.properties.maintex_uvst.xy + ctx.properties.maintex_uvst.zw;
 
     return vo;
 }
 
 [shader("fragment")]
-float4 fragMain(FragmentInput input : Varyings) : SV_Target {
+float4 fragMain(FragmentInput input : Varyings, Peridot::FragmentShaderContext ctx) : SV_Target {
     // return float4(input.uv, 1.0, 1.0);
-    float4 col = PeridotMaterialParameters::maintex.Sample(input.uv);
+    float4 col = ctx.properties.maintex.Sample(input.uv);
     col.rgb *= col.a;
     return col;
 }

--- a/examples/sprite-atlas/assets/shaders/unlit_image_atlas.prc
+++ b/examples/sprite-atlas/assets/shaders/unlit_image_atlas.prc
@@ -26,7 +26,7 @@ struct FragmentInput {
 VertexOutput vertMain(Vertex v, Peridot::VertexShaderContext ctx) {
     VertexOutput vo;
 
-    vo.pos = ctx.worldToClipSpace(v.pos);
+    vo.pos = ctx.objectToClipSpace(v.pos);
     vo.fragmentInput.uv = v.uv.xy * ctx.properties.maintex_uvst.xy + ctx.properties.maintex_uvst.zw;
 
     return vo;

--- a/examples/sprite-atlas/src/lib.rs
+++ b/examples/sprite-atlas/src/lib.rs
@@ -126,6 +126,7 @@ pub async fn game_main(e: &mut peridot::Engine<'_, impl peridot::NativeLinker>) 
             ref variants,
         } => {
             let peridot_rendering_configuration::Code {
+                push_constant_buffer_size_bytes,
                 ref vertex_semantic_to_location,
                 ref vertex_entry_point_name,
                 ref fragment_entry_point_name,
@@ -162,10 +163,10 @@ pub async fn game_main(e: &mut peridot::Engine<'_, impl peridot::NativeLinker>) 
                         dsl_sb1.as_transparent_ref(),
                         dsl_mat.as_transparent_ref(),
                     ],
-                    &if shader.push_constant_buffer_size_bytes > 0 {
+                    &if push_constant_buffer_size_bytes > 0 {
                         vec![br::PushConstantRange::new(
                             br::vk::VK_SHADER_STAGE_ALL,
-                            0..shader.push_constant_buffer_size_bytes as _,
+                            0..push_constant_buffer_size_bytes as _,
                         )]
                     } else {
                         vec![]

--- a/examples/sprite-atlas/src/lib.rs
+++ b/examples/sprite-atlas/src/lib.rs
@@ -93,30 +93,8 @@ pub async fn game_main(e: &mut peridot::Engine<'_, impl peridot::NativeLinker>) 
         ]),
     )
     .expect("dsl_sb1 new");
-    let dsl_mat = br::DescriptorSetLayoutObject::new(
-        e.graphics().device().clone(),
-        &br::DescriptorSetLayoutCreateInfo::new(
-            &shader
-                .descriptor_set_bindings
-                .iter()
-                .enumerate()
-                .map(|(n, t)| match t {
-                    peridot_rendering_configuration::DescriptorTypeVk::CombinedImageSampler => {
-                        br::DescriptorType::CombinedImageSampler.make_binding(n as _, 1)
-                    }
-                    peridot_rendering_configuration::DescriptorTypeVk::UniformBuffer { .. } => {
-                        br::DescriptorType::UniformBuffer.make_binding(n as _, 1)
-                    }
-                    peridot_rendering_configuration::DescriptorTypeVk::StorageBuffer { .. } => {
-                        br::DescriptorType::StorageBuffer.make_binding(n as _, 1)
-                    }
-                })
-                .collect::<Vec<_>>(),
-        ),
-    )
-    .expect("dsl_mat new");
 
-    let (pipeline_layout, mut pipeline);
+    let (dsl_mat, descriptor_sizes, pipeline_layout, mut pipeline);
     match shader.passes["Unlit"] {
         peridot_rendering_configuration::ShadingPassVk::SimpleDeriveBuiltinPass { .. } => {
             unimplemented!("SimpleDeriveBuiltinPass")
@@ -127,11 +105,53 @@ pub async fn game_main(e: &mut peridot::Engine<'_, impl peridot::NativeLinker>) 
         } => {
             let peridot_rendering_configuration::Code {
                 push_constant_buffer_size_bytes,
+                ref descriptor_set_bindings,
                 ref vertex_semantic_to_location,
                 ref vertex_entry_point_name,
                 ref fragment_entry_point_name,
                 ref words,
             } = variants[&peridot_rendering_configuration::VariantKey { instancing: true }];
+
+            dsl_mat = br::DescriptorSetLayoutObject::new(
+                e.graphics().device().clone(),
+                &br::DescriptorSetLayoutCreateInfo::new(
+                    &descriptor_set_bindings
+                        .iter()
+                        .enumerate()
+                        .map(|(n, t)| match t {
+                            peridot_rendering_configuration::DescriptorTypeVk::CombinedImageSampler => {
+                                br::DescriptorType::CombinedImageSampler.make_binding(n as _, 1)
+                            }
+                            peridot_rendering_configuration::DescriptorTypeVk::UniformBuffer { .. } => {
+                                br::DescriptorType::UniformBuffer.make_binding(n as _, 1)
+                            }
+                            peridot_rendering_configuration::DescriptorTypeVk::StorageBuffer { .. } => {
+                                br::DescriptorType::StorageBuffer.make_binding(n as _, 1)
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                ),
+            )
+            .expect("dsl_mat new");
+            descriptor_sizes = descriptor_set_bindings
+                .iter()
+                .enumerate()
+                .map(|(n, t)| match t {
+                    peridot_rendering_configuration::DescriptorTypeVk::CombinedImageSampler => {
+                        br::DescriptorType::CombinedImageSampler.make_size(1)
+                    }
+                    peridot_rendering_configuration::DescriptorTypeVk::UniformBuffer { .. } => {
+                        br::DescriptorType::UniformBuffer.make_size(1)
+                    }
+                    peridot_rendering_configuration::DescriptorTypeVk::StorageBuffer { .. } => {
+                        br::DescriptorType::StorageBuffer.make_size(1)
+                    }
+                })
+                .chain([
+                    br::DescriptorType::UniformBuffer.make_size(1),
+                    br::DescriptorType::StorageBuffer.make_size(1),
+                ])
+                .collect::<Vec<_>>();
 
             let scissor_rects = [br::Extent2D::from(screen_size).into_rect(br::Offset2D::ZERO)];
             let viewports = [scissor_rects[0].make_viewport(0.0..1.0)];
@@ -461,26 +481,7 @@ pub async fn game_main(e: &mut peridot::Engine<'_, impl peridot::NativeLinker>) 
         e.graphics().device().clone(),
         &br::DescriptorPoolCreateInfo::new(
             3,
-            &shader
-                .descriptor_set_bindings
-                .iter()
-                .enumerate()
-                .map(|(n, t)| match t {
-                    peridot_rendering_configuration::DescriptorTypeVk::CombinedImageSampler => {
-                        br::DescriptorType::CombinedImageSampler.make_size(1)
-                    }
-                    peridot_rendering_configuration::DescriptorTypeVk::UniformBuffer { .. } => {
-                        br::DescriptorType::UniformBuffer.make_size(1)
-                    }
-                    peridot_rendering_configuration::DescriptorTypeVk::StorageBuffer { .. } => {
-                        br::DescriptorType::StorageBuffer.make_size(1)
-                    }
-                })
-                .chain([
-                    br::DescriptorType::UniformBuffer.make_size(1),
-                    br::DescriptorType::StorageBuffer.make_size(1),
-                ])
-                .collect::<Vec<_>>(),
+            &descriptor_sizes,
         ),
     )
     .expect("descriptor pool create");

--- a/modules/rendering-configuration/Cargo.toml
+++ b/modules/rendering-configuration/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
-default = ["debug-dumps"]
+default = []
 with-loader-impl = ["dep:peridot"]
 with-asset-processing = ["dep:peridot-asset-processing", "compilation"]
 compilation = ["dep:slang", "dep:thiserror"]

--- a/modules/rendering-configuration/Cargo.toml
+++ b/modules/rendering-configuration/Cargo.toml
@@ -8,6 +8,7 @@ default = []
 with-loader-impl = ["dep:peridot"]
 with-asset-processing = ["dep:peridot-asset-processing", "compilation"]
 compilation = ["dep:slang", "dep:thiserror"]
+debug-dumps = ["dep:spirv-tools"]
 
 [dependencies]
 peridot-serialization-utils = { path = "../serialization-utils" }
@@ -21,6 +22,7 @@ futures-io = { workspace = true }
 futures-util = { workspace = true, features = ["io"] }
 peridot-native-io = { path = "../native-io" }
 pinned-futures-helper.path = "../../base-lib/pinned-futures-helper"
+spirv-tools = { path = "../../thirdparty/spirv-tools", optional = true }
 
 [lints]
 workspace = true

--- a/modules/rendering-configuration/Cargo.toml
+++ b/modules/rendering-configuration/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
-default = []
+default = ["debug-dumps"]
 with-loader-impl = ["dep:peridot"]
 with-asset-processing = ["dep:peridot-asset-processing", "compilation"]
 compilation = ["dep:slang", "dep:thiserror"]

--- a/modules/rendering-configuration/src/compilation.rs
+++ b/modules/rendering-configuration/src/compilation.rs
@@ -50,7 +50,6 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
 
     let mut asset = CompiledRenderingConfigurationVk {
         property_mappings: HashMap::new(),
-        descriptor_set_bindings: Vec::new(),
         passes: HashMap::new(),
     };
     let mut has_failure = false;
@@ -87,7 +86,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
             let (prelude, property_mapping, descriptor_set_bindings) =
                 rc.gen_vk_prelude(v.instancing);
             asset.property_mappings = property_mapping;
-            asset.descriptor_set_bindings = descriptor_set_bindings;
+            let mut descriptor_set_bindings = descriptor_set_bindings;
 
             let code = p.gen_vk_code();
             let generated_code = format!("{prelude}\n{code}");
@@ -221,11 +220,10 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                 let tl = refl
                     .type_layout(t, slang::ffi::SLANG_LAYOUT_RULES_DEFAULT)
                     .expect("no type layout for uniform property block");
-                asset
-                    .descriptor_set_bindings
-                    .push(DescriptorTypeVk::UniformBuffer {
-                        size_bytes: tl.size(slang::reflection::ParameterCategory::Uniform),
-                    });
+
+                descriptor_set_bindings.push(DescriptorTypeVk::UniformBuffer {
+                    size_bytes: tl.size(slang::reflection::ParameterCategory::Uniform),
+                });
             }
             if let Some(t) =
                 refl.find_type_by_name(c"Peridot.MaterialParameters.InstancedPropertyBlock")
@@ -233,21 +231,19 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                 let tl = refl
                     .type_layout(t, slang::ffi::SLANG_LAYOUT_RULES_DEFAULT)
                     .expect("no type layout for uniform property block");
-                asset
-                    .descriptor_set_bindings
-                    .push(DescriptorTypeVk::StorageBuffer {
-                        size_bytes: tl.size(slang::reflection::ParameterCategory::Uniform),
-                    });
+
+                descriptor_set_bindings.push(DescriptorTypeVk::StorageBuffer {
+                    size_bytes: tl.size(slang::reflection::ParameterCategory::Uniform),
+                });
             }
             if let Some(t) = refl.find_type_by_name(c"Peridot.MaterialParameters.RealtimeBuffer") {
                 let tl = refl
                     .type_layout(t, slang::ffi::SLANG_LAYOUT_RULES_DEFAULT)
                     .expect("no type layout for realtime buffer");
-                asset
-                    .descriptor_set_bindings
-                    .push(DescriptorTypeVk::UniformBuffer {
-                        size_bytes: tl.size(slang::reflection::ParameterCategory::Uniform),
-                    });
+
+                descriptor_set_bindings.push(DescriptorTypeVk::UniformBuffer {
+                    size_bytes: tl.size(slang::reflection::ParameterCategory::Uniform),
+                });
             }
             let mut vertex_semantic_to_location = HashMap::new();
             let mut vertex_entry_point_name = None;
@@ -375,6 +371,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                 v,
                 Code {
                     push_constant_buffer_size_bytes,
+                    descriptor_set_bindings,
                     vertex_semantic_to_location,
                     vertex_entry_point_name,
                     fragment_entry_point_name,

--- a/modules/rendering-configuration/src/compilation.rs
+++ b/modules/rendering-configuration/src/compilation.rs
@@ -92,6 +92,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
 
             let (code, semantic_to_location) = p.gen_vk_code(v.instancing);
             let generated_code = format!("{prelude}\n{code}");
+            #[cfg(feature = "debug-dumps")]
             println!("{generated_code}");
 
             let session = match slang_session.create_session(&slang::SessionDesc {
@@ -215,6 +216,30 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                     code.get_buffer_size(),
                 );
                 aligned_code.set_len(aligned_code.capacity());
+            }
+
+            #[cfg(feature = "debug-dumps")]
+            {
+                eprintln!("compilation done");
+                let st_context = spirv_tools::Context::new(spirv_tools::ffi::SPV_ENV_VULKAN_1_4);
+                let text = st_context
+                    .binary_to_text(
+                        &aligned_code,
+                        spirv_tools::ffi::SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES,
+                        None,
+                    )
+                    .expect("spvBinaryToText");
+                let cstr = text.as_cstr();
+                match cstr.to_str() {
+                    Err(_) => {
+                        tracing::warn!(target: "spirv-tools disasm", code = ?cstr);
+                    }
+                    Ok(x) => {
+                        for l in x.lines() {
+                            eprintln!("[disasm] {l}");
+                        }
+                    }
+                }
             }
 
             let refl = program.get_layout(0, None);

--- a/modules/rendering-configuration/src/compilation.rs
+++ b/modules/rendering-configuration/src/compilation.rs
@@ -92,6 +92,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
 
             let (code, semantic_to_location) = p.gen_vk_code(v.instancing);
             let generated_code = format!("{prelude}\n{code}");
+
             #[cfg(feature = "debug-dumps")]
             println!("{generated_code}");
 
@@ -107,6 +108,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                     continue;
                 }
             };
+
             let mut diag = core::mem::MaybeUninit::new(None);
             let module = session.load_module_from_source_string(
                 c"main",
@@ -114,19 +116,8 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                 &CString::new(generated_code).expect("invalid code generated"),
                 Some(&mut diag),
             );
-            let diag = unsafe { diag.assume_init() };
-            if let Some(d) = diag {
-                let str = unsafe { core::ffi::CStr::from_ptr(d.get_buffer_pointer().cast()) };
-                match str.to_str() {
-                    Err(x) => {
-                        tracing::warn!(target: "libslang diag", to_str_err = ?x, msg = ?str);
-                    }
-                    Ok(x) => {
-                        for l in x.lines() {
-                            eprintln!("[libslang] {l}");
-                        }
-                    }
-                }
+            if let Some(d) = unsafe { diag.assume_init() } {
+                print_slang_diag(&d);
             }
             let Some(module) = module else {
                 tracing::error!("Failed to load generated slang module");
@@ -145,30 +136,22 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                     continue;
                 }
             });
-            for e in module.iter_defined_entry_point() {
-                let e = match e {
-                    Ok(x) => x,
-                    Err(e) => {
+            program_components.extend(
+                module.iter_defined_entry_point().filter_map(|e| {
+                    e.inspect_err(|e| {
                         tracing::error!(reason = ?e, "Failed to iterate entry points");
                         has_failure = true;
-                        continue;
-                    }
-                };
-
-                program_components.push(match e.clone_cast() {
-                Ok(x) => x,
-                Err(e) => {
-                    tracing::error!(reason = ?e, "Failed to cast entry point object to IComponentType");
-                    has_failure = true;
-                    continue;
-                }
-            });
-            }
+                    }).ok()?.clone_cast().inspect_err(|e| {
+                        tracing::error!(reason = ?e, "Failed to cast entry point object to IComponentType");
+                        has_failure = true;
+                    }).ok()
+                })
+            );
             let mut diag = core::mem::MaybeUninit::new(None);
             let program =
                 session.create_composite_component_type(&program_components, Some(&mut diag));
             if let Some(d) = unsafe { diag.assume_init() } {
-                tracing::warn!(target: "libslang diag", msg = ?unsafe { core::ffi::CStr::from_ptr(d.get_buffer_pointer() as _) });
+                print_slang_diag(&d);
             }
             let program = match program {
                 Ok(x) => x,
@@ -182,7 +165,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
             let mut diag = core::mem::MaybeUninit::new(None);
             let linked = program.link(Some(&mut diag));
             if let Some(d) = unsafe { diag.assume_init() } {
-                tracing::warn!(target: "libslang diag", msg = ?unsafe { core::ffi::CStr::from_ptr(d.get_buffer_pointer() as _) });
+                print_slang_diag(&d);
             }
             let linked = match linked {
                 Ok(x) => x,
@@ -196,7 +179,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
             let mut diag = core::mem::MaybeUninit::new(None);
             let code = linked.get_target_code(0, Some(&mut diag));
             if let Some(d) = unsafe { diag.assume_init() } {
-                tracing::warn!(target: "libslang diag", msg = ?unsafe { core::ffi::CStr::from_ptr(d.get_buffer_pointer() as _) });
+                print_slang_diag(&d);
             }
             let code = match code {
                 Ok(x) => x,
@@ -219,31 +202,10 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
             }
 
             #[cfg(feature = "debug-dumps")]
-            {
-                eprintln!("compilation done");
-                let st_context = spirv_tools::Context::new(spirv_tools::ffi::SPV_ENV_VULKAN_1_4);
-                let text = st_context
-                    .binary_to_text(
-                        &aligned_code,
-                        spirv_tools::ffi::SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES,
-                        None,
-                    )
-                    .expect("spvBinaryToText");
-                let cstr = text.as_cstr();
-                match cstr.to_str() {
-                    Err(_) => {
-                        tracing::warn!(target: "spirv-tools disasm", code = ?cstr);
-                    }
-                    Ok(x) => {
-                        for l in x.lines() {
-                            eprintln!("[disasm] {l}");
-                        }
-                    }
-                }
-            }
+            dump_spv_disasm(&aligned_code);
 
             let refl = program.get_layout(0, None);
-            if let Some(t) = refl.find_type_by_name(c"PeridotMaterialParameters.PerDrawCall") {
+            if let Some(t) = refl.find_type_by_name(c"Peridot.MaterialParameters.PerDrawCall") {
                 let tl = refl
                     .type_layout(t, slang::ffi::SLANG_LAYOUT_RULES_DEFAULT)
                     .expect("no type layout for uniform block");
@@ -251,7 +213,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                     tl.size(slang::reflection::ParameterCategory::PushConstantBuffer);
             }
             if let Some(t) =
-                refl.find_type_by_name(c"PeridotMaterialParameters.UniformPropertyBlock")
+                refl.find_type_by_name(c"Peridot.MaterialParameters.UniformPropertyBlock")
             {
                 let tl = refl
                     .type_layout(t, slang::ffi::SLANG_LAYOUT_RULES_DEFAULT)
@@ -263,7 +225,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                     });
             }
             if let Some(t) =
-                refl.find_type_by_name(c"PeridotMaterialParameters.InstancedPropertyBlock")
+                refl.find_type_by_name(c"Peridot.MaterialParameters.InstancedPropertyBlock")
             {
                 let tl = refl
                     .type_layout(t, slang::ffi::SLANG_LAYOUT_RULES_DEFAULT)
@@ -274,7 +236,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                         size_bytes: tl.size(slang::reflection::ParameterCategory::Uniform),
                     });
             }
-            if let Some(t) = refl.find_type_by_name(c"PeridotMaterialParameters.RealtimeBuffer") {
+            if let Some(t) = refl.find_type_by_name(c"Peridot.MaterialParameters.RealtimeBuffer") {
                 let tl = refl
                     .type_layout(t, slang::ffi::SLANG_LAYOUT_RULES_DEFAULT)
                     .expect("no type layout for realtime buffer");
@@ -337,4 +299,41 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
     }
 
     (!has_failure).then_some(asset)
+}
+
+fn print_slang_diag(diag: &(impl slang::IBlob + ?Sized)) {
+    let str = unsafe { core::ffi::CStr::from_ptr(diag.get_buffer_pointer().cast()) };
+    match str.to_str() {
+        Err(x) => {
+            tracing::warn!(target: "libslang diag", to_str_err = ?x, msg = ?str);
+        }
+        Ok(x) => {
+            for l in x.lines() {
+                eprintln!("[libslang] {l}");
+            }
+        }
+    }
+}
+
+#[cfg(feature = "debug-dumps")]
+fn dump_spv_disasm(code: &[u32]) {
+    let st_context = spirv_tools::Context::new(spirv_tools::ffi::SPV_ENV_VULKAN_1_4);
+    let text = st_context
+        .binary_to_text(
+            code,
+            spirv_tools::ffi::SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES,
+            None,
+        )
+        .expect("spvBinaryToText");
+    let cstr = text.as_cstr();
+    match cstr.to_str() {
+        Err(_) => {
+            tracing::warn!(target: "spirv-tools disasm", code = ?cstr);
+        }
+        Ok(x) => {
+            for l in x.lines() {
+                eprintln!("[disasm] {l}");
+            }
+        }
+    }
 }

--- a/modules/rendering-configuration/src/compilation.rs
+++ b/modules/rendering-configuration/src/compilation.rs
@@ -92,6 +92,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
 
             let (code, semantic_to_location) = p.gen_vk_code(v.instancing);
             let generated_code = format!("{prelude}\n{code}");
+            println!("{generated_code}");
 
             let session = match slang_session.create_session(&slang::SessionDesc {
                 targets: targets.as_ptr(),
@@ -112,7 +113,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                 &CString::new(generated_code).expect("invalid code generated"),
                 Some(&mut diag),
             );
-            let diag = unsafe { diag.assume_init_ref() };
+            let diag = unsafe { diag.assume_init() };
             if let Some(d) = diag {
                 let str = unsafe { core::ffi::CStr::from_ptr(d.get_buffer_pointer().cast()) };
                 match str.to_str() {

--- a/modules/rendering-configuration/src/compilation.rs
+++ b/modules/rendering-configuration/src/compilation.rs
@@ -112,8 +112,19 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                 &CString::new(generated_code).expect("invalid code generated"),
                 Some(&mut diag),
             );
-            if let Some(d) = unsafe { diag.assume_init() } {
-                tracing::warn!(target: "libslang diag", msg = ?unsafe { core::ffi::CStr::from_ptr(d.get_buffer_pointer() as _) });
+            let diag = unsafe { diag.assume_init_ref() };
+            if let Some(d) = diag {
+                let str = unsafe { core::ffi::CStr::from_ptr(d.get_buffer_pointer().cast()) };
+                match str.to_str() {
+                    Err(x) => {
+                        tracing::warn!(target: "libslang diag", to_str_err = ?x, msg = ?str);
+                    }
+                    Ok(x) => {
+                        for l in x.lines() {
+                            eprintln!("[libslang] {l}");
+                        }
+                    }
+                }
             }
             let Some(module) = module else {
                 tracing::error!("Failed to load generated slang module");

--- a/modules/rendering-configuration/src/compilation.rs
+++ b/modules/rendering-configuration/src/compilation.rs
@@ -51,7 +51,6 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
     let mut asset = CompiledRenderingConfigurationVk {
         property_mappings: HashMap::new(),
         descriptor_set_bindings: Vec::new(),
-        push_constant_buffer_size_bytes: 0,
         passes: HashMap::new(),
     };
     let mut has_failure = false;
@@ -205,13 +204,17 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
             dump_spv_disasm(&aligned_code);
 
             let refl = program.get_layout(0, None);
-            if let Some(t) = refl.find_type_by_name(c"Peridot.MaterialParameters.PerDrawCall") {
+            let push_constant_buffer_size_bytes = if let Some(t) =
+                refl.find_type_by_name(c"Peridot.MaterialParameters.PerDrawCall")
+            {
                 let tl = refl
                     .type_layout(t, slang::ffi::SLANG_LAYOUT_RULES_DEFAULT)
                     .expect("no type layout for uniform block");
-                asset.push_constant_buffer_size_bytes =
-                    tl.size(slang::reflection::ParameterCategory::PushConstantBuffer);
-            }
+
+                tl.size(slang::reflection::ParameterCategory::PushConstantBuffer)
+            } else {
+                0
+            };
             if let Some(t) =
                 refl.find_type_by_name(c"Peridot.MaterialParameters.UniformPropertyBlock")
             {
@@ -371,6 +374,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
             variants.insert(
                 v,
                 Code {
+                    push_constant_buffer_size_bytes,
                     vertex_semantic_to_location,
                     vertex_entry_point_name,
                     fragment_entry_point_name,

--- a/modules/rendering-configuration/src/compilation.rs
+++ b/modules/rendering-configuration/src/compilation.rs
@@ -59,7 +59,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
         let tracing_span = tracing::span!(tracing::Level::TRACE, "compile_pass", name = %n);
         let _tracing_span_enter = tracing_span.enter();
 
-        if p.shader_code.is_none() && p.vertex_bindings.is_empty() && p.option_overrides.is_none() {
+        if p.shader_code.is_none() && p.option_overrides.is_none() {
             // simple derive
             let deriving = p
                 .deriving
@@ -90,7 +90,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
             asset.property_mappings = property_mapping;
             asset.descriptor_set_bindings = descriptor_set_bindings;
 
-            let (code, semantic_to_location) = p.gen_vk_code(v.instancing);
+            let code = p.gen_vk_code();
             let generated_code = format!("{prelude}\n{code}");
 
             #[cfg(feature = "debug-dumps")]
@@ -246,6 +246,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                         size_bytes: tl.size(slang::reflection::ParameterCategory::Uniform),
                     });
             }
+            let mut vertex_semantic_to_location = HashMap::new();
             let mut vertex_entry_point_name = None;
             let mut fragment_entry_point_name = None;
             for ep in refl.iter_entry_point() {
@@ -258,6 +259,95 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
                     } else {
                         vertex_entry_point_name =
                             Some(ep.name().to_str().expect("invalid entry name").into());
+
+                        println!("vertex inputs");
+                        for x in ep.iter_parameter() {
+                            let is_vertex_input = x
+                                .variable()
+                                .iter_user_attribute()
+                                .any(|a| a.name() == c"Peridot_VertexInput")
+                                || x.r#type()
+                                    .iter_user_attribute()
+                                    .any(|a| a.name() == c"Peridot_VertexInput");
+                            if !is_vertex_input {
+                                continue;
+                            }
+
+                            rec(x, &mut vertex_semantic_to_location, &mut has_failure);
+                            fn rec(
+                                v: &slang::reflection::VariableLayout,
+                                vertex_semantic_to_location: &mut HashMap<
+                                    peridot_semantic_shader::VertexInputSemantic,
+                                    u32,
+                                >,
+                                has_failure: &mut bool,
+                            ) {
+                                let tl = v.type_layout();
+
+                                if tl.kind() == slang::reflection::TypeKind::Struct {
+                                    // process each fields recursively
+                                    for m in tl.iter_field() {
+                                        rec(m, vertex_semantic_to_location, has_failure);
+                                    }
+
+                                    return;
+                                }
+
+                                let Some(semantic_name) = v.semantic_name() else {
+                                    tracing::error!(var_name = ?v.name(), "vertex input variables should have semantic");
+                                    *has_failure = true;
+                                    return;
+                                };
+                                let semantic_name = match semantic_name.to_str() {
+                                    Ok(x) => x,
+                                    Err(e) => {
+                                        tracing::error!(reason = ?e, var_name = ?v.name(), ?semantic_name, "invalid semantic_name bytes");
+                                        *has_failure = true;
+                                        return;
+                                    }
+                                };
+
+                                let semantic = if semantic_name.eq_ignore_ascii_case("position") {
+                                    peridot_semantic_shader::VertexInputSemantic::Position(
+                                        v.semantic_index() as _,
+                                    )
+                                } else if semantic_name.eq_ignore_ascii_case("normal") {
+                                    peridot_semantic_shader::VertexInputSemantic::Normal(
+                                        v.semantic_index() as _,
+                                    )
+                                } else if semantic_name.eq_ignore_ascii_case("tangent") {
+                                    peridot_semantic_shader::VertexInputSemantic::Tangent(
+                                        v.semantic_index() as _,
+                                    )
+                                } else if semantic_name.eq_ignore_ascii_case("binormal") {
+                                    peridot_semantic_shader::VertexInputSemantic::Binormal(
+                                        v.semantic_index() as _,
+                                    )
+                                } else if semantic_name.eq_ignore_ascii_case("texcoord") {
+                                    peridot_semantic_shader::VertexInputSemantic::Texcoord(
+                                        v.semantic_index() as _,
+                                    )
+                                } else if semantic_name.eq_ignore_ascii_case("color") {
+                                    peridot_semantic_shader::VertexInputSemantic::Color(
+                                        v.semantic_index() as _,
+                                    )
+                                } else if semantic_name.eq_ignore_ascii_case("misc") {
+                                    peridot_semantic_shader::VertexInputSemantic::Misc(
+                                        v.semantic_index() as _,
+                                    )
+                                } else {
+                                    tracing::warn!(
+                                        var_name = ?v.name(),
+                                        semantic_name,
+                                        "unsupported semantic name, skipping"
+                                    );
+                                    return;
+                                };
+
+                                vertex_semantic_to_location
+                                    .insert(semantic, v.binding_index() as _);
+                            }
+                        }
                     }
                 } else if stage == slang::ffi::SLANG_STAGE_FRAGMENT {
                     if let Some(ref x) = fragment_entry_point_name {
@@ -281,7 +371,7 @@ pub fn compile(src: &str) -> Option<CompiledRenderingConfigurationVk> {
             variants.insert(
                 v,
                 Code {
-                    vertex_semantic_to_location: semantic_to_location,
+                    vertex_semantic_to_location,
                     vertex_entry_point_name,
                     fragment_entry_point_name,
                     words: aligned_code,

--- a/modules/rendering-configuration/src/compilation/codegen.rs
+++ b/modules/rendering-configuration/src/compilation/codegen.rs
@@ -76,7 +76,6 @@ impl RenderingConfiguration {
                             option_overrides: None,
                             instancing_support: InstancingSupport::None,
                             deriving: Some(org_name.as_str().into()),
-                            vertex_bindings: Vec::new(),
                             shader_code: None,
                         },
                     );
@@ -86,31 +85,12 @@ impl RenderingConfiguration {
                     contents,
                     ..
                 }) => {
-                    let mut vertex_bindings = None;
                     let mut shader_code = None;
                     let mut option_overrides = None::<RenderingOptionOverrides>;
                     let mut instancing_support = None::<InstancingSupport>;
 
                     for c in contents {
                         match c {
-                            syntax::PassBlockContent::VertexBindingsBlock { entries, .. } => {
-                                if vertex_bindings.is_some() {
-                                    panic!("duplicate vertex bindings block");
-                                }
-
-                                vertex_bindings = Some(
-                                    entries
-                                        .into_iter()
-                                        .map(|(name, _, ty, _, semantic_name, _)| {
-                                            PassVertexBindingData {
-                                                name: name.as_str().into(),
-                                                r#type: property_type_from_syntax(ty),
-                                                semantic: parse_vi_semantic(&semantic_name),
-                                            }
-                                        })
-                                        .collect(),
-                                );
-                            }
                             syntax::PassBlockContent::ShaderBlock { content, .. } => {
                                 if shader_code.is_some() {
                                     panic!("duplicate shader block");
@@ -207,7 +187,6 @@ impl RenderingConfiguration {
                             option_overrides,
                             instancing_support: instancing_support.unwrap_or_default(),
                             deriving: None,
-                            vertex_bindings: vertex_bindings.unwrap_or_else(Vec::new),
                             shader_code,
                         },
                     );
@@ -505,9 +484,18 @@ impl RenderingConfiguration {
         let mut fsh_context_block = String::new();
 
         // builtin prelude
-        code.push_str("namespace Peridot {\n");
+
+        code.push_str(
+            r#"[__AttributeUsage(_AttributeTargets.Param)]
+[__AttributeUsage(_AttributeTargets.Struct)]
+struct Peridot_VertexInputAttribute {}
+
+namespace Peridot {
+"#,
+        );
         vsh_context_block.push_str("struct VertexShaderContext {");
         fsh_context_block.push_str("struct FragmentShaderContext {");
+
         if instancing {
             vsh_context_block.push_str(
                 r#"
@@ -734,50 +722,19 @@ pub struct PassData {
     pub option_overrides: Option<RenderingOptionOverrides>,
     pub instancing_support: InstancingSupport,
     pub deriving: Option<String>,
-    pub vertex_bindings: Vec<PassVertexBindingData>,
     pub shader_code: Option<String>,
 }
 impl PassData {
-    pub fn gen_vk_code(&self, for_instancing: bool) -> (String, HashMap<VertexInputSemantic, u32>) {
-        let mut semantic_to_location_map = HashMap::with_capacity(self.vertex_bindings.len());
-
+    pub fn gen_vk_code(&self) -> String {
         let mut code = String::new();
         if let Some(ref d) = self.deriving {
             eprintln!("todo: deriving: {d}");
-        }
-        if !self.vertex_bindings.is_empty() {
-            code.push_str("struct Vertex {\n");
-            for (n, vb) in self.vertex_bindings.iter().enumerate() {
-                match semantic_to_location_map.entry(vb.semantic.clone()) {
-                    std::collections::hash_map::Entry::Vacant(x) => {
-                        x.insert(n as _);
-                    }
-                    std::collections::hash_map::Entry::Occupied(x) => {
-                        panic!(
-                            "conflicting vertex semantic {:?} with location {}",
-                            x.key(),
-                            x.get()
-                        );
-                    }
-                }
-
-                code.push_str("    [vk::location(");
-                code.push_str(&n.to_string());
-                code.push_str(")]\n    ");
-                print_property_type(&vb.r#type, &mut code);
-                code.push(' ');
-                code.push_str(&vb.name);
-                code.push_str(" : ");
-                print_vi_semantic(&vb.semantic, &mut code);
-                code.push_str(";\n");
-            }
-            code.push_str("}\n\n");
         }
         if let Some(ref s) = self.shader_code {
             code.push_str(s);
         }
 
-        (code, semantic_to_location_map)
+        code
     }
 }
 

--- a/modules/rendering-configuration/src/compilation/codegen.rs
+++ b/modules/rendering-configuration/src/compilation/codegen.rs
@@ -577,7 +577,7 @@ ConstantBuffer<ObjectParameters> objectParameters;
 
 "#,
         );
-        code.push_str("namespace MaterialParameters {");
+        code.push_str("namespace MaterialParameters {\n");
         for (n, (name, ty)) in specialized_constants.into_iter().enumerate() {
             code.push_str("[vk::constant_id(");
             code.push_str(&n.to_string());

--- a/modules/rendering-configuration/src/compilation/codegen.rs
+++ b/modules/rendering-configuration/src/compilation/codegen.rs
@@ -727,7 +727,7 @@ ConstantBuffer<ObjectParameters> objectParameters;
         fsh_context_block.push_str("    }\n");
 
         // contextual helper
-        vsh_context_block.push_str("\n    inline float4 worldToClipSpace(float4 p) { return mul(this.cameraParameters.viewProjectionMatrix, mul(this.objectParameters.transformMatrix, p)); }\n");
+        vsh_context_block.push_str("\n    inline float4 objectToClipSpace(float4 p) { return mul(this.cameraParameters.viewProjectionMatrix, mul(this.objectParameters.transformMatrix, p)); }\n");
 
         vsh_context_block.push_str("}\n");
         fsh_context_block.push_str("}\n");

--- a/modules/rendering-configuration/src/compilation/codegen.rs
+++ b/modules/rendering-configuration/src/compilation/codegen.rs
@@ -683,6 +683,7 @@ ConstantBuffer<ObjectParameters> objectParameters;
             binding_index += 1;
         }
 
+        // TODO: instancing: falseのときUniformにバッファをまとめるべきか？
         if !storage_entries.instanced_property_buffer_members.is_empty() {
             code.push_str("struct InstancedPropertyBlock {\n");
             for (name, ty) in storage_entries.instanced_property_buffer_members {

--- a/modules/rendering-configuration/src/compilation/codegen.rs
+++ b/modules/rendering-configuration/src/compilation/codegen.rs
@@ -501,76 +501,83 @@ impl RenderingConfiguration {
         }
 
         let mut code = String::new();
+        let mut vsh_context_block = String::new();
+        let mut fsh_context_block = String::new();
 
         // builtin prelude
+        code.push_str("namespace Peridot {\n");
+        vsh_context_block.push_str("struct VertexShaderContext {");
+        fsh_context_block.push_str("struct FragmentShaderContext {");
         if instancing {
-            code.push_str(
-                r#"namespace PeridotInstancing {
-struct Vars {
-    uint id : SV_InstanceID;
-    uint baseIndex : SV_StartInstanceLocation;
+            vsh_context_block.push_str(
+                r#"
+    uint instanceID : SV_InstanceID;
+    uint baseInstanceIndex: SV_StartInstanceLocation;
 
     property uint instanceIndex {
-        inline get { return this.baseIndex + this.id; }
+        inline get { return this.baseInstanceIndex + this.instanceID; }
     }
-}
-}
-            "#,
+"#,
             );
-        } else {
-            code.push_str("#define PERIDOT_INSTANCE_VARS \n");
         }
 
         code.push_str(
-            r#"namespace PeridotCameraParameters {
-struct UniformBlock {
+            r#"
+struct CameraParameters {
     float4x4 viewProjectionMatrix;
 }
 [vk::binding(0, 0)]
-ConstantBuffer<UniformBlock> uniformBlock;
-
-static inline float4x4 viewProjectionMatrix() {
-    return uniformBlock.viewProjectionMatrix;
-}
-}
+ConstantBuffer<CameraParameters> cameraParameters;
 "#,
+        );
+        vsh_context_block.push_str("\n    property CameraParameters cameraParameters { inline get { return Peridot::cameraParameters; } }\n");
+
+        code.push_str(
+            r#"
+struct ObjectParameters {
+    float4x4 transformMatrix;
+}"#,
         );
         if instancing {
             code.push_str(
-                r#"namespace PeridotObjectParameters {
-struct UniformBlock {
-    float4x4 transformMatrix;
-}
+                r#"
 [vk::binding(0, 1)]
-StructuredBuffer<UniformBlock> uniformBlock;
-
-static inline float4x4 transformMatrix(PeridotInstancing::Vars instanceVars) {
-    return uniformBlock[instanceVars.instanceIndex].transformMatrix;
-}
-}
-#define PERIDOT_OBJECT_PARAMETERS_ARGS(v) v.__peridot_instanceVars
+StructuredBuffer<ObjectParameters> objectParameters;
 "#,
             );
+
+            vsh_context_block.push_str("\n    property ObjectParameters objectParameters { inline get { return Peridot::objectParameters[this.instanceIndex]; } }\n");
         } else {
             code.push_str(
-                r#"namespace PeridotObjectParameters {
-struct UniformBlock {
-    float4x4 transformMatrix;
-}
+                r#"
 [vk::binding(0, 1)]
-ConstantBuffer<UniformBlock> uniformBlock;
-
-static inline float4x4 transformMatrix() {
-    return uniformBlock.transformMatrix;
-}
-}
-#define PERIDOT_OBJECT_PARAMETERS_ARGS(v) 
+ConstantBuffer<ObjectParameters> objectParameters;
 "#,
             );
+
+            vsh_context_block.push_str("\n    property ObjectParameters objectParameters { inline get { return Peridot::objectParameters; } }\n");
         }
 
         // material prelude
-        code.push_str("namespace PeridotMaterialParameters {\n");
+        vsh_context_block.push_str(
+            r#"
+    property Properties properties { inline get { return Properties(this); } }
+
+    struct Properties {
+        VertexShaderContext ctx;
+
+"#,
+        );
+        fsh_context_block.push_str(
+            r#"
+    property Properties properties { inline get { return Properties(this); } }
+
+    struct Properties {
+        FragmentShaderContext ctx;
+
+"#,
+        );
+        code.push_str("namespace MaterialParameters {");
         for (n, (name, ty)) in specialized_constants.into_iter().enumerate() {
             code.push_str("[vk::constant_id(");
             code.push_str(&n.to_string());
@@ -607,6 +614,22 @@ static inline float4x4 transformMatrix() {
             code.push_str(&name);
             code.push_str(";\n");
 
+            vsh_context_block.push_str("        property ");
+            print_property_type(ty, &mut vsh_context_block);
+            vsh_context_block.push(' ');
+            vsh_context_block.push_str(&name);
+            vsh_context_block.push_str(" { inline get { return MaterialParameters::");
+            vsh_context_block.push_str(&name);
+            vsh_context_block.push_str("; } }\n");
+
+            fsh_context_block.push_str("        property ");
+            print_property_type(ty, &mut fsh_context_block);
+            fsh_context_block.push(' ');
+            fsh_context_block.push_str(&name);
+            fsh_context_block.push_str(" { inline get { return MaterialParameters::");
+            fsh_context_block.push_str(&name);
+            fsh_context_block.push_str("; } }\n");
+
             descriptor_set_bindings.push(match ty {
                 PropertyType::Texture2D => DescriptorTypeVk::CombinedImageSampler,
                 x => {
@@ -639,6 +662,14 @@ static inline float4x4 transformMatrix() {
                 code.push(' ');
                 code.push_str(&name);
                 code.push_str(";\n");
+
+                vsh_context_block.push_str("\n        property ");
+                print_property_type(ty, &mut vsh_context_block);
+                vsh_context_block.push(' ');
+                vsh_context_block.push_str(&name);
+                vsh_context_block.push_str(" { inline get { return MaterialParameters::instancedProperty[this.ctx.instanceIndex].");
+                vsh_context_block.push_str(&name);
+                vsh_context_block.push_str("; } }\n");
             }
             // set indexはあとで調整(直接うめこみたくはないな......)
             writeln!(code, "}}\n[vk::binding({binding_index}, 2)] StructuredBuffer<InstancedPropertyBlock> instancedProperty;").expect("write failed");
@@ -663,7 +694,19 @@ static inline float4x4 transformMatrix() {
             .expect("write failed");
         }
 
+        vsh_context_block.push_str("    }\n");
+        fsh_context_block.push_str("    }\n");
+
+        // contextual helper
+        vsh_context_block.push_str("\n    inline float4 worldToClipSpace(float4 p) { return mul(this.cameraParameters.viewProjectionMatrix, mul(this.objectParameters.transformMatrix, p)); }\n");
+
+        vsh_context_block.push_str("}\n");
+        fsh_context_block.push_str("}\n");
         code.push_str("}\n");
+        code.push_str(&vsh_context_block);
+        code.push_str(&fsh_context_block);
+        code.push_str("}\n");
+
         (code, property_mapping, descriptor_set_bindings)
     }
 }
@@ -727,9 +770,6 @@ impl PassData {
                 code.push_str(" : ");
                 print_vi_semantic(&vb.semantic, &mut code);
                 code.push_str(";\n");
-            }
-            if for_instancing {
-                code.push_str("    PeridotInstancing::Vars __peridot_instanceVars;\n");
             }
             code.push_str("}\n\n");
         }

--- a/modules/rendering-configuration/src/compilation/codegen.rs
+++ b/modules/rendering-configuration/src/compilation/codegen.rs
@@ -1,14 +1,12 @@
 use std::{borrow::Cow, collections::HashMap};
 
-use peridot_semantic_shader::VertexInputSemantic;
-
 use crate::{
     DescriptorTypeVk, FaceCulling, FrontFace, InstancingSupport, PolygonRasterizationMode,
     PropertyDestinationVk, PropertyMappingVk, PropertyType, RenderingOptionOverrides,
     VectorPropertyMappingVk,
 };
 
-use super::{syntax, tokenizer::Identifier};
+use super::{syntax, tokenizer};
 
 #[derive(Debug)]
 pub struct RenderingConfiguration {
@@ -23,47 +21,7 @@ impl RenderingConfiguration {
         for elem in s {
             match elem {
                 syntax::ToplevelElement::PropertiesBlock(ps) => {
-                    #[derive(Default)]
-                    struct Attributes {
-                        immutable: bool,
-                        per_draw_call: bool,
-                        instanceable: bool,
-                    }
-
-                    let mut attr = Attributes::default();
-                    for p in ps.elements {
-                        match p {
-                            syntax::PropertiesBlockElement::Attribute(a) => {
-                                if a.name.as_str() == "Immutable" {
-                                    attr.immutable = true;
-                                } else if a.name.as_str() == "PerDrawCall" {
-                                    attr.per_draw_call = true;
-                                } else if a.name.as_str() == "Instanceable" {
-                                    attr.instanceable = true;
-                                } else {
-                                    panic!("unknown attribute: {:?}", a.name);
-                                }
-                            }
-                            syntax::PropertiesBlockElement::Property(p) => {
-                                let update_frequency = if attr.immutable {
-                                    PropertyUpdateFrequency::Immutable
-                                } else if attr.per_draw_call {
-                                    PropertyUpdateFrequency::PerDrawCall
-                                } else {
-                                    PropertyUpdateFrequency::default()
-                                };
-
-                                properties.push(PropertyData {
-                                    name: p.name.as_str().into(),
-                                    r#type: property_type_from_syntax(p.r#type),
-                                    default: fold_expr(p.default),
-                                    update_frequency,
-                                    instanceable: attr.instanceable,
-                                });
-                                attr = Attributes::default();
-                            }
-                        }
-                    }
+                    Self::collect_properties(ps, &mut properties);
                 }
                 syntax::ToplevelElement::PassBlock(syntax::PassBlock::SimpleDerive {
                     name,
@@ -85,116 +43,171 @@ impl RenderingConfiguration {
                     contents,
                     ..
                 }) => {
-                    let mut shader_code = None;
-                    let mut option_overrides = None::<RenderingOptionOverrides>;
-                    let mut instancing_support = None::<InstancingSupport>;
-
-                    for c in contents {
-                        match c {
-                            syntax::PassBlockContent::ShaderBlock { content, .. } => {
-                                if shader_code.is_some() {
-                                    panic!("duplicate shader block");
-                                }
-
-                                shader_code = Some(content.into());
-                            }
-                            syntax::PassBlockContent::RenderOptions { entries, .. } => {
-                                let o = option_overrides.get_or_insert_default();
-                                for (e, _) in entries {
-                                    if e.as_str() == "PointPolygon" {
-                                        if let Some(m) = o.mode {
-                                            panic!("conflicting PolygonRasterizationMode: {m:?}");
-                                        }
-
-                                        o.mode = Some(PolygonRasterizationMode::Point);
-                                    } else if e.as_str() == "LinedPolygon" {
-                                        if let Some(m) = o.mode {
-                                            panic!("conflicting PolygonRasterizationMode: {m:?}");
-                                        }
-
-                                        o.mode = Some(PolygonRasterizationMode::Line);
-                                    } else if e.as_str() == "FilledPolygon" {
-                                        if let Some(m) = o.mode {
-                                            panic!("conflicting PolygonRasterizationMode: {m:?}");
-                                        }
-
-                                        o.mode = Some(PolygonRasterizationMode::Fill);
-                                    } else if e.as_str() == "NoCulling" {
-                                        if let Some(x) = o.culling {
-                                            panic!("conflicting FaceCulling: {x:?}");
-                                        }
-
-                                        o.culling = Some(FaceCulling::None);
-                                    } else if e.as_str() == "CullFront" {
-                                        if let Some(x) = o.culling {
-                                            panic!("conflicting FaceCulling: {x:?}");
-                                        }
-
-                                        o.culling = Some(FaceCulling::Front);
-                                    } else if e.as_str() == "CullBack" {
-                                        if let Some(x) = o.culling {
-                                            panic!("conflicting FaceCulling: {x:?}");
-                                        }
-
-                                        o.culling = Some(FaceCulling::Back);
-                                    } else if e.as_str() == "CullBoth" {
-                                        if let Some(x) = o.culling {
-                                            panic!("conflicting FaceCulling: {x:?}");
-                                        }
-
-                                        o.culling = Some(FaceCulling::Both);
-                                    } else if e.as_str() == "CounterClockwiseAsFront" {
-                                        if let Some(x) = o.front_face {
-                                            panic!("conflicting FrontFace: {x:?}");
-                                        }
-
-                                        o.front_face = Some(FrontFace::CounterClockwise);
-                                    } else if e.as_str() == "ClockwiseAsFront" {
-                                        if let Some(x) = o.front_face {
-                                            panic!("conflicting FrontFace: {x:?}");
-                                        }
-
-                                        o.front_face = Some(FrontFace::Clockwise);
-                                    } else if e.as_str() == "NotInstanced" {
-                                        if let Some(x) = instancing_support {
-                                            panic!("conflicting Instancing: {x:?}");
-                                        }
-
-                                        instancing_support = Some(InstancingSupport::None);
-                                    } else if e.as_str() == "Instanced" {
-                                        if let Some(x) = instancing_support {
-                                            panic!("conflicting Instancing: {x:?}");
-                                        }
-
-                                        instancing_support = Some(InstancingSupport::Allowed);
-                                    } else if e.as_str() == "InstancedOnly" {
-                                        if let Some(x) = instancing_support {
-                                            panic!("conflicting Instancing: {x:?}");
-                                        }
-
-                                        instancing_support = Some(InstancingSupport::Only);
-                                    } else {
-                                        panic!("unknown option: {}", e.as_str());
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    passes.insert(
-                        name.as_str().into(),
-                        PassData {
-                            option_overrides,
-                            instancing_support: instancing_support.unwrap_or_default(),
-                            deriving: None,
-                            shader_code,
-                        },
-                    );
+                    passes.insert(name.as_str().into(), Self::collect_pass_data(contents));
                 }
             }
         }
 
         Self { properties, passes }
+    }
+
+    fn collect_properties(syn: syntax::PropertiesBlock, sink: &mut Vec<PropertyData>) {
+        #[derive(Default)]
+        struct Attributes {
+            update_freq: Option<PropertyUpdateFrequency>,
+            instanceable: bool,
+        }
+
+        let mut attr = Attributes::default();
+        for p in syn.elements {
+            match p {
+                syntax::PropertiesBlockElement::Attribute(a) => {
+                    if a.name.as_str() == "Immutable" {
+                        if attr.update_freq.is_some() {
+                            panic!("conflicting update frequency attribute");
+                        }
+                        attr.update_freq = Some(PropertyUpdateFrequency::Immutable);
+                    } else if a.name.as_str() == "PerDrawCall" {
+                        if attr.update_freq.is_some() {
+                            panic!("conflicting update frequency attribute");
+                        }
+                        attr.update_freq = Some(PropertyUpdateFrequency::PerDrawCall);
+                    } else if a.name.as_str() == "Realtime" {
+                        if attr.update_freq.is_some() {
+                            panic!("conflicting update frequency attribute");
+                        }
+                        attr.update_freq = Some(PropertyUpdateFrequency::Realtime);
+                    } else if a.name.as_str() == "Instanceable" {
+                        attr.instanceable = true;
+                    } else {
+                        panic!("unknown attribute: {:?}", a.name);
+                    }
+                }
+                syntax::PropertiesBlockElement::Property(p) => {
+                    sink.push(PropertyData {
+                        name: p.name.as_str().into(),
+                        r#type: property_type_from_syntax(p.r#type),
+                        default: fold_expr(p.default),
+                        update_frequency: attr.update_freq.unwrap_or_default(),
+                        instanceable: attr.instanceable,
+                    });
+                    attr = Attributes::default();
+                }
+            }
+        }
+    }
+
+    fn collect_pass_data(contents: Vec<syntax::PassBlockContent>) -> PassData {
+        let mut shader_code = None;
+        let mut option_overrides = None::<RenderingOptionOverrides>;
+        let mut instancing_support = None::<InstancingSupport>;
+
+        for c in contents {
+            match c {
+                syntax::PassBlockContent::ShaderBlock { content, .. } => {
+                    if shader_code.is_some() {
+                        panic!("duplicate shader block");
+                    }
+
+                    shader_code = Some(content.into());
+                }
+                syntax::PassBlockContent::RenderOptions { entries, .. } => {
+                    let o = option_overrides.get_or_insert_default();
+                    for (e, _) in entries {
+                        Self::collect_render_option(e, o, &mut instancing_support);
+                    }
+                }
+            }
+        }
+
+        PassData {
+            option_overrides,
+            instancing_support: instancing_support.unwrap_or_default(),
+            deriving: None,
+            shader_code,
+        }
+    }
+
+    fn collect_render_option(
+        opt: tokenizer::Identifier,
+        sink: &mut RenderingOptionOverrides,
+        instancing_support: &mut Option<InstancingSupport>,
+    ) {
+        if opt.as_str() == "PointPolygon" {
+            if let Some(m) = sink.mode {
+                panic!("conflicting PolygonRasterizationMode: {m:?}");
+            }
+
+            sink.mode = Some(PolygonRasterizationMode::Point);
+        } else if opt.as_str() == "LinedPolygon" {
+            if let Some(m) = sink.mode {
+                panic!("conflicting PolygonRasterizationMode: {m:?}");
+            }
+
+            sink.mode = Some(PolygonRasterizationMode::Line);
+        } else if opt.as_str() == "FilledPolygon" {
+            if let Some(m) = sink.mode {
+                panic!("conflicting PolygonRasterizationMode: {m:?}");
+            }
+
+            sink.mode = Some(PolygonRasterizationMode::Fill);
+        } else if opt.as_str() == "NoCulling" {
+            if let Some(x) = sink.culling {
+                panic!("conflicting FaceCulling: {x:?}");
+            }
+
+            sink.culling = Some(FaceCulling::None);
+        } else if opt.as_str() == "CullFront" {
+            if let Some(x) = sink.culling {
+                panic!("conflicting FaceCulling: {x:?}");
+            }
+
+            sink.culling = Some(FaceCulling::Front);
+        } else if opt.as_str() == "CullBack" {
+            if let Some(x) = sink.culling {
+                panic!("conflicting FaceCulling: {x:?}");
+            }
+
+            sink.culling = Some(FaceCulling::Back);
+        } else if opt.as_str() == "CullBoth" {
+            if let Some(x) = sink.culling {
+                panic!("conflicting FaceCulling: {x:?}");
+            }
+
+            sink.culling = Some(FaceCulling::Both);
+        } else if opt.as_str() == "CounterClockwiseAsFront" {
+            if let Some(x) = sink.front_face {
+                panic!("conflicting FrontFace: {x:?}");
+            }
+
+            sink.front_face = Some(FrontFace::CounterClockwise);
+        } else if opt.as_str() == "ClockwiseAsFront" {
+            if let Some(x) = sink.front_face {
+                panic!("conflicting FrontFace: {x:?}");
+            }
+
+            sink.front_face = Some(FrontFace::Clockwise);
+        } else if opt.as_str() == "NotInstanced" {
+            if let Some(x) = instancing_support {
+                panic!("conflicting Instancing: {x:?}");
+            }
+
+            *instancing_support = Some(InstancingSupport::None);
+        } else if opt.as_str() == "Instanced" {
+            if let Some(x) = instancing_support {
+                panic!("conflicting Instancing: {x:?}");
+            }
+
+            *instancing_support = Some(InstancingSupport::Allowed);
+        } else if opt.as_str() == "InstancedOnly" {
+            if let Some(x) = instancing_support {
+                panic!("conflicting Instancing: {x:?}");
+            }
+
+            *instancing_support = Some(InstancingSupport::Only);
+        } else {
+            panic!("unknown option: {}", opt.as_str());
+        }
     }
 
     // いったんターゲットをVulkanに限定する(他API対応もでてきたらそのときに対応する)
@@ -208,55 +221,118 @@ impl RenderingConfiguration {
     ) {
         use core::fmt::Write;
 
-        let mut specialized_constants = Vec::<(Cow<str>, &PropertyType)>::new();
+        struct StorageEntryEmitter<'s> {
+            specialized_constants: Vec<(Cow<'s, str>, &'s PropertyType)>,
+            push_constant_block_members: Vec<(Cow<'s, str>, &'s PropertyType)>,
+            descriptor_sets: Vec<(Cow<'s, str>, &'s PropertyType)>,
+            uniform_buffer_members: Vec<(Cow<'s, str>, &'s PropertyType)>,
+            instanced_property_buffer_members: Vec<(Cow<'s, str>, &'s PropertyType)>,
+            realtime_buffer_members: Vec<(Cow<'s, str>, &'s PropertyType)>,
+        }
+        impl<'s> StorageEntryEmitter<'s> {
+            pub fn new() -> Self {
+                Self {
+                    specialized_constants: Vec::new(),
+                    push_constant_block_members: Vec::new(),
+                    descriptor_sets: Vec::new(),
+                    uniform_buffer_members: Vec::new(),
+                    instanced_property_buffer_members: Vec::new(),
+                    realtime_buffer_members: Vec::new(),
+                }
+            }
+
+            pub fn add_specialized_constant(
+                &mut self,
+                name: Cow<'s, str>,
+                r#type: &'s PropertyType,
+            ) -> PropertyDestinationVk {
+                self.specialized_constants.push((name, r#type));
+                PropertyDestinationVk::SpecConstant(self.specialized_constants.len() - 1)
+            }
+
+            pub fn add_push_constant_block_member(
+                &mut self,
+                name: Cow<'s, str>,
+                r#type: &'s PropertyType,
+            ) -> PropertyDestinationVk {
+                self.push_constant_block_members.push((name, r#type));
+                PropertyDestinationVk::PushConstantBlock(self.push_constant_block_members.len() - 1)
+            }
+
+            pub fn add_descriptor_set_member(
+                &mut self,
+                name: Cow<'s, str>,
+                r#type: &'s PropertyType,
+            ) -> PropertyDestinationVk {
+                self.descriptor_sets.push((name, r#type));
+                PropertyDestinationVk::DescriptorSet(self.descriptor_sets.len() - 1)
+            }
+
+            pub fn add_uniform_buffer_member(
+                &mut self,
+                name: Cow<'s, str>,
+                r#type: &'s PropertyType,
+            ) -> PropertyDestinationVk {
+                self.uniform_buffer_members.push((name, r#type));
+                PropertyDestinationVk::DescriptorSetUniformBuffer(
+                    self.uniform_buffer_members.len() - 1,
+                )
+            }
+
+            pub fn add_instance_buffer_member(
+                &mut self,
+                name: Cow<'s, str>,
+                r#type: &'s PropertyType,
+            ) -> PropertyDestinationVk {
+                self.instanced_property_buffer_members.push((name, r#type));
+                PropertyDestinationVk::InstanceBuffer(
+                    self.instanced_property_buffer_members.len() - 1,
+                )
+            }
+
+            pub fn add_realtime_buffer_member(
+                &mut self,
+                name: Cow<'s, str>,
+                r#type: &'s PropertyType,
+            ) -> PropertyDestinationVk {
+                self.realtime_buffer_members.push((name, r#type));
+                PropertyDestinationVk::RealtimeBuffer(self.realtime_buffer_members.len() - 1)
+            }
+        }
+
+        let mut storage_entries = StorageEntryEmitter::new();
         let mut combined_constants = Vec::new();
-        let mut push_constant_block_members = Vec::new();
-        let mut descriptor_sets = Vec::new();
-        let mut descriptor_set_uniform_buffer_members = Vec::new();
-        let mut descriptor_set_bindings = Vec::new();
-        let mut realtime_buffer_members = Vec::new();
         let mut property_mapping = HashMap::new();
-        let mut instanced_property_buffer_members = Vec::new();
 
         for p in self.properties.iter() {
             match p.r#type {
                 PropertyType::Texture2D => {
                     let uvst_var_name = Cow::Owned(format!("{}_uvst", p.name));
+                    const UVST_PROPERTY_TYPE: PropertyType = PropertyType::Float4;
                     // Texture2Dはuvstだけどこに入るかが変わる
                     let uvst_dest = match (p.instanceable, &p.update_frequency) {
-                        (true, _) => {
-                            instanced_property_buffer_members
-                                .push((uvst_var_name, &PropertyType::Float4));
-                            VectorPropertyMappingVk::Direct(PropertyDestinationVk::InstanceBuffer(
-                                instanced_property_buffer_members.len() - 1,
-                            ))
-                        }
+                        (true, _) => VectorPropertyMappingVk::Direct(
+                            storage_entries
+                                .add_instance_buffer_member(uvst_var_name, &UVST_PROPERTY_TYPE),
+                        ),
                         // そのままspecialized constantsにできないのでスカラ型に分解
                         (false, PropertyUpdateFrequency::Immutable) => {
-                            let x_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
-                                format!("{name}_X", name = uvst_var_name).into(),
+                            let x_dest = storage_entries.add_specialized_constant(
+                                format!("{uvst_var_name}_X").into(),
                                 &PropertyType::Float,
-                            ));
-                            let y_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
-                                format!("{name}_Y", name = uvst_var_name).into(),
+                            );
+                            let y_dest = storage_entries.add_specialized_constant(
+                                format!("{uvst_var_name}_Y").into(),
                                 &PropertyType::Float,
-                            ));
-                            let z_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
-                                format!("{name}_Z", name = uvst_var_name).into(),
+                            );
+                            let z_dest = storage_entries.add_specialized_constant(
+                                format!("{uvst_var_name}_Z").into(),
                                 &PropertyType::Float,
-                            ));
-                            let w_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
-                                format!("{name}_W", name = uvst_var_name).into(),
+                            );
+                            let w_dest = storage_entries.add_specialized_constant(
+                                format!("{uvst_var_name}_W").into(),
                                 &PropertyType::Float,
-                            ));
+                            );
 
                             combined_constants.push(format!(
                                 "static const float4 {name} = float4({name}_X, {name}_Y, {name}_Z, {name}_W);", name = uvst_var_name
@@ -264,35 +340,30 @@ impl RenderingConfiguration {
                             VectorPropertyMappingVk::Splitted(vec![x_dest, y_dest, z_dest, w_dest])
                         }
                         (false, PropertyUpdateFrequency::PerDrawCall) => {
-                            push_constant_block_members
-                                .push((uvst_var_name, &PropertyType::Float4));
                             VectorPropertyMappingVk::Direct(
-                                PropertyDestinationVk::PushConstantBlock(
-                                    push_constant_block_members.len() - 1,
+                                storage_entries.add_push_constant_block_member(
+                                    uvst_var_name,
+                                    &UVST_PROPERTY_TYPE,
                                 ),
                             )
                         }
                         (false, PropertyUpdateFrequency::Dynamic) => {
-                            descriptor_set_uniform_buffer_members
-                                .push((uvst_var_name, &PropertyType::Float4));
                             VectorPropertyMappingVk::Direct(
-                                PropertyDestinationVk::DescriptorSetUniformBuffer(
-                                    descriptor_set_uniform_buffer_members.len() - 1,
-                                ),
+                                storage_entries
+                                    .add_uniform_buffer_member(uvst_var_name, &UVST_PROPERTY_TYPE),
                             )
                         }
                         (false, PropertyUpdateFrequency::Realtime) => {
-                            realtime_buffer_members.push((uvst_var_name, &PropertyType::Float4));
-                            VectorPropertyMappingVk::Direct(PropertyDestinationVk::RealtimeBuffer(
-                                realtime_buffer_members.len() - 1,
-                            ))
+                            VectorPropertyMappingVk::Direct(
+                                storage_entries
+                                    .add_realtime_buffer_member(uvst_var_name, &UVST_PROPERTY_TYPE),
+                            )
                         }
                     };
 
                     // もの本体はDescriptorSetにしか入れられない
-                    descriptor_sets.push((Cow::Borrowed(&p.name), &p.r#type));
-                    let object_dest =
-                        PropertyDestinationVk::DescriptorSet(descriptor_sets.len() - 1);
+                    let object_dest = storage_entries
+                        .add_descriptor_set_member(Cow::Borrowed(&p.name), &p.r#type);
 
                     match property_mapping.entry(p.name.clone()) {
                         std::collections::hash_map::Entry::Vacant(x) => {
@@ -312,17 +383,11 @@ impl RenderingConfiguration {
                 _ => match (p.instanceable, &p.update_frequency) {
                     (true, _) => {
                         // 一旦Instanceableマークされたプロパティは全部同じStorageにいれる（Realtimeとかは分割したほうがいいかもしれないけど必要になりそうなら検討）
-                        instanced_property_buffer_members.push((Cow::Borrowed(&p.name), &p.r#type));
+                        let dest = storage_entries
+                            .add_instance_buffer_member(Cow::Borrowed(&p.name), &p.r#type);
                         match property_mapping.entry(p.name.clone()) {
                             std::collections::hash_map::Entry::Vacant(x) => {
-                                x.insert((
-                                    p.r#type.clone(),
-                                    PropertyMappingVk::Direct(
-                                        PropertyDestinationVk::InstanceBuffer(
-                                            instanced_property_buffer_members.len() - 1,
-                                        ),
-                                    ),
-                                ));
+                                x.insert((p.r#type.clone(), PropertyMappingVk::Direct(dest)));
                             }
                             std::collections::hash_map::Entry::Occupied(x) => {
                                 panic!("property {} conflicting with {:?}", x.key(), x.get());
@@ -332,22 +397,19 @@ impl RenderingConfiguration {
                     // compound typeはそのままspecialized constantsにできないのでスカラ型に分解
                     (false, PropertyUpdateFrequency::Immutable) => match p.r#type {
                         PropertyType::Float2 => {
-                            let r_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
+                            let r_dest = storage_entries.add_specialized_constant(
                                 format!("{name}_R", name = p.name).into(),
                                 &PropertyType::Float,
-                            ));
-                            let g_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
+                            );
+                            let g_dest = storage_entries.add_specialized_constant(
                                 format!("{name}_G", name = p.name).into(),
                                 &PropertyType::Float,
-                            ));
+                            );
                             combined_constants.push(format!(
                                 "static const float2 {name} = float2({name}_R, {name}_G);",
                                 name = p.name
                             ));
+
                             match property_mapping.entry(p.name.clone()) {
                                 std::collections::hash_map::Entry::Vacant(x) => {
                                     x.insert((
@@ -361,33 +423,27 @@ impl RenderingConfiguration {
                             }
                         }
                         PropertyType::Float4 | PropertyType::RGB => {
-                            let r_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
+                            let r_dest = storage_entries.add_specialized_constant(
                                 format!("{name}_R", name = p.name).into(),
                                 &PropertyType::Float,
-                            ));
-                            let g_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
+                            );
+                            let g_dest = storage_entries.add_specialized_constant(
                                 format!("{name}_G", name = p.name).into(),
                                 &PropertyType::Float,
-                            ));
-                            let b_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
+                            );
+                            let b_dest = storage_entries.add_specialized_constant(
                                 format!("{name}_B", name = p.name).into(),
                                 &PropertyType::Float,
-                            ));
-                            let a_dest =
-                                PropertyDestinationVk::SpecConstant(specialized_constants.len());
-                            specialized_constants.push((
+                            );
+                            let a_dest = storage_entries.add_specialized_constant(
                                 format!("{name}_A", name = p.name).into(),
                                 &PropertyType::Float,
-                            ));
+                            );
                             combined_constants.push(format!(
-                            "static const float4 {name} = float4({name}_R, {name}_G, {name}_B, {name}_A);", name = p.name
-                        ));
+                                "static const float4 {name} = float4({name}_R, {name}_G, {name}_B, {name}_A);",
+                                name = p.name
+                            ));
+
                             match property_mapping.entry(p.name.clone()) {
                                 std::collections::hash_map::Entry::Vacant(x) => {
                                     x.insert((
@@ -403,17 +459,12 @@ impl RenderingConfiguration {
                             }
                         }
                         _ => {
-                            specialized_constants.push(((&p.name).into(), &p.r#type));
+                            let dest = storage_entries
+                                .add_specialized_constant(Cow::Borrowed(&p.name), &p.r#type);
+
                             match property_mapping.entry(p.name.clone()) {
                                 std::collections::hash_map::Entry::Vacant(x) => {
-                                    x.insert((
-                                        p.r#type.clone(),
-                                        PropertyMappingVk::Direct(
-                                            PropertyDestinationVk::SpecConstant(
-                                                specialized_constants.len() - 1,
-                                            ),
-                                        ),
-                                    ));
+                                    x.insert((p.r#type.clone(), PropertyMappingVk::Direct(dest)));
                                 }
                                 std::collections::hash_map::Entry::Occupied(x) => {
                                     panic!("property {} conflicting with {:?}", x.key(), x.get());
@@ -422,17 +473,12 @@ impl RenderingConfiguration {
                         }
                     },
                     (false, PropertyUpdateFrequency::PerDrawCall) => {
-                        push_constant_block_members.push((Cow::Borrowed(&p.name), &p.r#type));
+                        let dest = storage_entries
+                            .add_push_constant_block_member(Cow::Borrowed(&p.name), &p.r#type);
+
                         match property_mapping.entry(p.name.clone()) {
                             std::collections::hash_map::Entry::Vacant(x) => {
-                                x.insert((
-                                    p.r#type.clone(),
-                                    PropertyMappingVk::Direct(
-                                        PropertyDestinationVk::PushConstantBlock(
-                                            push_constant_block_members.len() - 1,
-                                        ),
-                                    ),
-                                ));
+                                x.insert((p.r#type.clone(), PropertyMappingVk::Direct(dest)));
                             }
                             std::collections::hash_map::Entry::Occupied(x) => {
                                 panic!("property {} conflicting with {:?}", x.key(), x.get());
@@ -440,17 +486,12 @@ impl RenderingConfiguration {
                         }
                     }
                     (false, PropertyUpdateFrequency::Dynamic) => {
-                        descriptor_sets.push((Cow::Borrowed(&p.name), &p.r#type));
+                        let dest = storage_entries
+                            .add_descriptor_set_member(Cow::Borrowed(&p.name), &p.r#type);
+
                         match property_mapping.entry(p.name.clone()) {
                             std::collections::hash_map::Entry::Vacant(x) => {
-                                x.insert((
-                                    p.r#type.clone(),
-                                    PropertyMappingVk::Direct(
-                                        PropertyDestinationVk::DescriptorSet(
-                                            descriptor_sets.len() - 1,
-                                        ),
-                                    ),
-                                ));
+                                x.insert((p.r#type.clone(), PropertyMappingVk::Direct(dest)));
                             }
                             std::collections::hash_map::Entry::Occupied(x) => {
                                 panic!("property {} conflicting with {:?}", x.key(), x.get());
@@ -458,17 +499,12 @@ impl RenderingConfiguration {
                         }
                     }
                     (false, PropertyUpdateFrequency::Realtime) => {
-                        realtime_buffer_members.push((Cow::Borrowed(&p.name), &p.r#type));
+                        let dest = storage_entries
+                            .add_realtime_buffer_member(Cow::Borrowed(&p.name), &p.r#type);
+
                         match property_mapping.entry(p.name.clone()) {
                             std::collections::hash_map::Entry::Vacant(x) => {
-                                x.insert((
-                                    p.r#type.clone(),
-                                    PropertyMappingVk::Direct(
-                                        PropertyDestinationVk::RealtimeBuffer(
-                                            realtime_buffer_members.len() - 1,
-                                        ),
-                                    ),
-                                ));
+                                x.insert((p.r#type.clone(), PropertyMappingVk::Direct(dest)));
                             }
                             std::collections::hash_map::Entry::Occupied(x) => {
                                 panic!("property {} conflicting with {:?}", x.key(), x.get());
@@ -566,7 +602,11 @@ ConstantBuffer<ObjectParameters> objectParameters;
 "#,
         );
         code.push_str("namespace MaterialParameters {\n");
-        for (n, (name, ty)) in specialized_constants.into_iter().enumerate() {
+        for (n, (name, ty)) in storage_entries
+            .specialized_constants
+            .into_iter()
+            .enumerate()
+        {
             code.push_str("[vk::constant_id(");
             code.push_str(&n.to_string());
             code.push_str(")]\nconst ");
@@ -581,9 +621,9 @@ ConstantBuffer<ObjectParameters> objectParameters;
             code.push('\n');
         }
 
-        if !push_constant_block_members.is_empty() {
+        if !storage_entries.push_constant_block_members.is_empty() {
             code.push_str("struct PerDrawCall {\n");
-            for (name, ty) in push_constant_block_members {
+            for (name, ty) in storage_entries.push_constant_block_members {
                 code.push_str("    ");
                 print_property_type(ty, &mut code);
                 code.push(' ');
@@ -593,8 +633,9 @@ ConstantBuffer<ObjectParameters> objectParameters;
             code.push_str("}\n[vk::push_constant]\nPerDrawCall perDrawCall;\n");
         }
 
+        let mut descriptor_set_bindings = Vec::new();
         let mut binding_index = 0;
-        for (name, ty) in descriptor_sets.into_iter() {
+        for (name, ty) in storage_entries.descriptor_sets {
             // set indexはあとで調整(直接うめこみたくはないな......)
             write!(code, "[vk::binding({binding_index}, 2)] ").expect("write failed");
             print_property_type(ty, &mut code);
@@ -627,9 +668,9 @@ ConstantBuffer<ObjectParameters> objectParameters;
             binding_index += 1;
         }
 
-        if !descriptor_set_uniform_buffer_members.is_empty() {
+        if !storage_entries.uniform_buffer_members.is_empty() {
             code.push_str("struct UniformPropertyBlock {\n");
-            for (name, ty) in descriptor_set_uniform_buffer_members {
+            for (name, ty) in storage_entries.uniform_buffer_members {
                 code.push_str("    ");
                 print_property_type(ty, &mut code);
                 code.push(' ');
@@ -642,9 +683,9 @@ ConstantBuffer<ObjectParameters> objectParameters;
             binding_index += 1;
         }
 
-        if !instanced_property_buffer_members.is_empty() {
+        if !storage_entries.instanced_property_buffer_members.is_empty() {
             code.push_str("struct InstancedPropertyBlock {\n");
-            for (name, ty) in instanced_property_buffer_members {
+            for (name, ty) in storage_entries.instanced_property_buffer_members {
                 code.push_str("    ");
                 print_property_type(ty, &mut code);
                 code.push(' ');
@@ -665,9 +706,9 @@ ConstantBuffer<ObjectParameters> objectParameters;
             binding_index += 1;
         }
 
-        if !realtime_buffer_members.is_empty() {
+        if !storage_entries.realtime_buffer_members.is_empty() {
             code.push_str("struct RealtimeBuffer {\n");
-            for (name, ty) in realtime_buffer_members {
+            for (name, ty) in storage_entries.realtime_buffer_members {
                 code.push_str("    ");
                 print_property_type(ty, &mut code);
                 code.push(' ');
@@ -738,13 +779,6 @@ impl PassData {
     }
 }
 
-#[derive(Debug)]
-pub struct PassVertexBindingData {
-    pub name: String,
-    pub r#type: PropertyType,
-    pub semantic: VertexInputSemantic,
-}
-
 fn property_type_from_syntax(x: syntax::Type) -> PropertyType {
     match x {
         syntax::Type::Texture2D(_) => PropertyType::Texture2D,
@@ -766,131 +800,6 @@ fn print_property_type(pt: &PropertyType, sink: &mut String) {
         PropertyType::Float => sink.push_str("float"),
         PropertyType::Float2 => sink.push_str("float2"),
         PropertyType::Float4 => sink.push_str("float4"),
-    }
-}
-
-fn parse_vi_semantic(x: &Identifier) -> VertexInputSemantic {
-    let l = x.as_str().to_uppercase();
-
-    'try_parse: {
-        if let Some(s) = l.strip_prefix("POSITION") {
-            let index = if s.is_empty() {
-                0
-            } else if let Ok(x) = s.parse() {
-                x
-            } else {
-                break 'try_parse;
-            };
-
-            return VertexInputSemantic::Position(index);
-        }
-
-        if let Some(s) = l.strip_prefix("NORMAL") {
-            let index = if s.is_empty() {
-                0
-            } else if let Ok(x) = s.parse() {
-                x
-            } else {
-                break 'try_parse;
-            };
-
-            return VertexInputSemantic::Normal(index);
-        }
-
-        if let Some(s) = l.strip_prefix("TANGENT") {
-            let index = if s.is_empty() {
-                0
-            } else if let Ok(x) = s.parse() {
-                x
-            } else {
-                break 'try_parse;
-            };
-
-            return VertexInputSemantic::Tangent(index);
-        }
-
-        if let Some(s) = l.strip_prefix("BINORMAL") {
-            let index = if s.is_empty() {
-                0
-            } else if let Ok(x) = s.parse() {
-                x
-            } else {
-                break 'try_parse;
-            };
-
-            return VertexInputSemantic::Binormal(index);
-        }
-
-        if let Some(s) = l.strip_prefix("TEXCOORD") {
-            let index = if s.is_empty() {
-                0
-            } else if let Ok(x) = s.parse() {
-                x
-            } else {
-                break 'try_parse;
-            };
-
-            return VertexInputSemantic::Texcoord(index);
-        }
-
-        if let Some(s) = l.strip_prefix("COLOR") {
-            let index = if s.is_empty() {
-                0
-            } else if let Ok(x) = s.parse() {
-                x
-            } else {
-                break 'try_parse;
-            };
-
-            return VertexInputSemantic::Color(index);
-        }
-
-        if let Some(s) = l.strip_prefix("MISC") {
-            let index = if s.is_empty() {
-                0
-            } else if let Ok(x) = s.parse() {
-                x
-            } else {
-                break 'try_parse;
-            };
-
-            return VertexInputSemantic::Misc(index);
-        }
-    }
-
-    panic!("invalid semantic name: {}", x.as_str());
-}
-
-fn print_vi_semantic(s: &VertexInputSemantic, sink: &mut String) {
-    match s {
-        VertexInputSemantic::Position(index) => {
-            sink.push_str("POSITION");
-            sink.push_str(&index.to_string());
-        }
-        VertexInputSemantic::Normal(index) => {
-            sink.push_str("NORMAL");
-            sink.push_str(&index.to_string());
-        }
-        VertexInputSemantic::Tangent(index) => {
-            sink.push_str("TANGENT");
-            sink.push_str(&index.to_string());
-        }
-        VertexInputSemantic::Binormal(index) => {
-            sink.push_str("BINORMAL");
-            sink.push_str(&index.to_string());
-        }
-        VertexInputSemantic::Texcoord(index) => {
-            sink.push_str("TEXCOORD");
-            sink.push_str(&index.to_string());
-        }
-        VertexInputSemantic::Color(index) => {
-            sink.push_str("COLOR");
-            sink.push_str(&index.to_string());
-        }
-        VertexInputSemantic::Misc(index) => {
-            sink.push_str("MISC");
-            sink.push_str(&index.to_string());
-        }
     }
 }
 

--- a/modules/rendering-configuration/src/compilation/syntax.rs
+++ b/modules/rendering-configuration/src/compilation/syntax.rs
@@ -2,8 +2,7 @@ use crate::compilation::tokenizer::{Located, Location};
 
 use super::tokenizer::{
     self, CloseBracket, CloseParen, Colon, Comma, Equal, Identifier, Keyword, KwEnd, KwPass,
-    KwProperties, KwRenderOption, KwShader, KwUse, KwVertexBindings, NumLit, OpenBracket,
-    OpenParen, StrLit, Token,
+    KwProperties, KwRenderOption, KwShader, KwUse, NumLit, OpenBracket, OpenParen, StrLit, Token,
 };
 
 pub struct ParserState<'s> {
@@ -331,18 +330,6 @@ pub enum PassBlockContent<'s> {
         render_option: KwRenderOption,
         entries: Vec<(Identifier<'s>, Option<Comma>)>,
     },
-    VertexBindingsBlock {
-        vertex_bindings: KwVertexBindings,
-        entries: Vec<(
-            Identifier<'s>,
-            Colon,
-            Type<'s>,
-            OpenBracket,
-            Identifier<'s>,
-            CloseBracket,
-        )>,
-        end: KwEnd,
-    },
     ShaderBlock {
         shader: KwShader,
         content: &'s str,
@@ -354,9 +341,6 @@ impl Located for PassBlockContent<'_> {
     fn location(&self) -> &Location {
         match self {
             Self::RenderOptions { render_option, .. } => render_option.location(),
-            Self::VertexBindingsBlock {
-                vertex_bindings, ..
-            } => vertex_bindings.location(),
             Self::ShaderBlock { shader, .. } => shader.location(),
         }
     }
@@ -394,42 +378,6 @@ impl<'s> PassBlockContent<'s> {
                     render_option,
                     entries,
                 })
-            }
-            Token::Keyword(Keyword::VertexBindings(vertex_bindings)) => {
-                let mut entries = Vec::new();
-                loop {
-                    match state.next()? {
-                        Token::Keyword(Keyword::End(end)) => {
-                            break Ok(PassBlockContent::VertexBindingsBlock {
-                                vertex_bindings,
-                                entries,
-                                end,
-                            });
-                        }
-                        Token::Identifier(name) => {
-                            let colon = match state.next()? {
-                                Token::Colon(x) => x,
-                                t => return Err(Error::unexpected_token(":", t)),
-                            };
-                            let ty = Type::parse(state)?;
-                            let semantic_start = match state.next()? {
-                                Token::OpenBracket(x) => x,
-                                t => return Err(Error::unexpected_token("[", t)),
-                            };
-                            let semantic = match state.next()? {
-                                Token::Identifier(x) => x,
-                                t => return Err(Error::unexpected_token("identifier", t)),
-                            };
-                            let semantic_end = match state.next()? {
-                                Token::CloseBracket(x) => x,
-                                t => return Err(Error::unexpected_token("]", t)),
-                            };
-
-                            entries.push((name, colon, ty, semantic_start, semantic, semantic_end));
-                        }
-                        t => return Err(Error::unexpected_token("identifier", t)),
-                    }
-                }
             }
             Token::Keyword(Keyword::Shader(shader)) => {
                 let Some((content, end)) = tokenizer::read_until_next_end(&mut state.tok) else {

--- a/modules/rendering-configuration/src/compilation/tokenizer.rs
+++ b/modules/rendering-configuration/src/compilation/tokenizer.rs
@@ -92,16 +92,6 @@ impl Located for KwShader {
 
 #[derive(Debug, Clone)]
 #[repr(transparent)]
-pub struct KwVertexBindings(Location);
-impl Located for KwVertexBindings {
-    #[inline(always)]
-    fn location(&self) -> &Location {
-        &self.0
-    }
-}
-
-#[derive(Debug, Clone)]
-#[repr(transparent)]
 pub struct KwRenderOption(Location);
 impl Located for KwRenderOption {
     #[inline(always)]
@@ -222,7 +212,6 @@ pub enum Keyword {
     Pass(KwPass),
     Use(KwUse),
     Shader(KwShader),
-    VertexBindings(KwVertexBindings),
     RenderOption(KwRenderOption),
 }
 impl Located for Keyword {
@@ -234,7 +223,6 @@ impl Located for Keyword {
             Self::Pass(KwPass(l)) => l,
             Self::Use(KwUse(l)) => l,
             Self::Shader(KwShader(l)) => l,
-            Self::VertexBindings(KwVertexBindings(l)) => l,
             Self::RenderOption(KwRenderOption(l)) => l,
         }
     }
@@ -491,9 +479,6 @@ pub fn next_token<'s>(ctx: &mut Context<'s>) -> Option<Token<'s>> {
         "Pass" => Token::Keyword(Keyword::Pass(KwPass(ctx.loc.clone()))),
         "Use" => Token::Keyword(Keyword::Use(KwUse(ctx.loc.clone()))),
         "Shader" => Token::Keyword(Keyword::Shader(KwShader(ctx.loc.clone()))),
-        "VertexBindings" => {
-            Token::Keyword(Keyword::VertexBindings(KwVertexBindings(ctx.loc.clone())))
-        }
         "RenderOption" => Token::Keyword(Keyword::RenderOption(KwRenderOption(ctx.loc.clone()))),
         t => Token::Identifier(Identifier(t, ctx.loc.clone())),
     };

--- a/modules/rendering-configuration/src/file.rs
+++ b/modules/rendering-configuration/src/file.rs
@@ -130,7 +130,6 @@ impl Header {
 pub struct PropertyDirectory {
     pub entries: Vec<(String, PropertyType, PropertyMappingVk)>,
     pub descriptor_set_bindings: Vec<DescriptorTypeVk>,
-    pub push_constant_buffer_size_bytes: usize,
 }
 impl PropertyDirectory {
     pub fn write(&self, sink: &mut impl Write) -> std::io::Result<usize> {
@@ -145,8 +144,6 @@ impl PropertyDirectory {
         for t in self.descriptor_set_bindings.iter() {
             writes += t.write(sink)?;
         }
-
-        writes += VariableUInt(self.push_constant_buffer_size_bytes as _).write(sink)?;
 
         Ok(writes)
     }
@@ -170,12 +167,9 @@ impl PropertyDirectory {
             descriptor_set_bindings.push(t);
         }
 
-        let push_constant_buffer_size_bytes = VariableUInt::read(source)?.0 as usize;
-
         Ok(Self {
             entries,
             descriptor_set_bindings,
-            push_constant_buffer_size_bytes,
         })
     }
 
@@ -201,13 +195,9 @@ impl PropertyDirectory {
             descriptor_set_bindings.push(t);
         }
 
-        let VariableUInt(push_constant_buffer_size_bytes) =
-            VariableUInt::read_async(source.as_mut()).await?;
-
         Ok(Self {
             entries,
             descriptor_set_bindings,
-            push_constant_buffer_size_bytes: push_constant_buffer_size_bytes as _,
         })
     }
 }
@@ -460,6 +450,7 @@ impl RenderingOptionOverrides {
 }
 
 pub struct Code {
+    pub push_constant_buffer_size_bytes: usize,
     pub vertex_semantic_to_location: Vec<(VertexInputSemantic, u32)>,
     pub vertex_entry_point_name: Option<String>,
     pub fragment_entry_point_name: Option<String>,
@@ -469,6 +460,7 @@ impl Code {
     pub fn write(&self, sink: &mut impl Write) -> std::io::Result<usize> {
         let mut writes = 0;
 
+        writes += VariableUInt(self.push_constant_buffer_size_bytes as _).write(sink)?;
         writes += VariableUInt(self.vertex_semantic_to_location.len() as _).write(sink)?;
         for (n, l) in self.vertex_semantic_to_location.iter() {
             writes += n.write(sink)?;
@@ -500,6 +492,7 @@ impl Code {
     }
 
     pub fn read(source: &mut impl BufRead) -> std::io::Result<Self> {
+        let push_constant_buffer_size_bytes = VariableUInt::read(source)?.0 as usize;
         let vertex_semantic_to_location_count = VariableUInt::read(source)?.0 as usize;
         let mut vertex_semantic_to_location = Vec::with_capacity(vertex_semantic_to_location_count);
         for _ in 0..vertex_semantic_to_location_count {
@@ -534,6 +527,7 @@ impl Code {
         }
 
         Ok(Self {
+            push_constant_buffer_size_bytes,
             vertex_semantic_to_location,
             vertex_entry_point_name,
             fragment_entry_point_name,
@@ -544,6 +538,8 @@ impl Code {
     pub async fn read_async(
         mut source: Pin<&mut (impl AsyncBufRead + ?Sized)>,
     ) -> std::io::Result<Self> {
+        let push_constant_buffer_size_bytes =
+            VariableUInt::read_async(source.as_mut()).await?.0 as usize;
         let vertex_semantic_to_location_count =
             VariableUInt::read_async(source.as_mut()).await?.0 as usize;
         let mut vertex_semantic_to_location = Vec::with_capacity(vertex_semantic_to_location_count);
@@ -579,6 +575,7 @@ impl Code {
         }
 
         Ok(Self {
+            push_constant_buffer_size_bytes,
             vertex_semantic_to_location,
             vertex_entry_point_name,
             fragment_entry_point_name,

--- a/modules/rendering-configuration/src/file.rs
+++ b/modules/rendering-configuration/src/file.rs
@@ -129,7 +129,6 @@ impl Header {
 
 pub struct PropertyDirectory {
     pub entries: Vec<(String, PropertyType, PropertyMappingVk)>,
-    pub descriptor_set_bindings: Vec<DescriptorTypeVk>,
 }
 impl PropertyDirectory {
     pub fn write(&self, sink: &mut impl Write) -> std::io::Result<usize> {
@@ -138,11 +137,6 @@ impl PropertyDirectory {
             writes += PascalStr(name).write(sink)?;
             writes += r#type.write(sink)?;
             writes += mapping_vk.write(sink)?;
-        }
-
-        writes += VariableUInt(self.descriptor_set_bindings.len() as _).write(sink)?;
-        for t in self.descriptor_set_bindings.iter() {
-            writes += t.write(sink)?;
         }
 
         Ok(writes)
@@ -159,18 +153,7 @@ impl PropertyDirectory {
             entries.push((name, r#type, mapping_vk));
         }
 
-        let descriptor_set_binding_count = VariableUInt::read(source)?.0 as usize;
-        let mut descriptor_set_bindings = Vec::with_capacity(descriptor_set_binding_count);
-        for _ in 0..descriptor_set_binding_count {
-            let t = DescriptorTypeVk::read(source)?;
-
-            descriptor_set_bindings.push(t);
-        }
-
-        Ok(Self {
-            entries,
-            descriptor_set_bindings,
-        })
+        Ok(Self { entries })
     }
 
     pub async fn read_async(
@@ -186,19 +169,7 @@ impl PropertyDirectory {
             entries.push((name, r#type, mapping_vk));
         }
 
-        let VariableUInt(descriptor_set_binding_count) =
-            VariableUInt::read_async(source.as_mut()).await?;
-        let mut descriptor_set_bindings = Vec::with_capacity(descriptor_set_binding_count as _);
-        for _ in 0..descriptor_set_binding_count {
-            let t = DescriptorTypeVk::read_async(source.as_mut()).await?;
-
-            descriptor_set_bindings.push(t);
-        }
-
-        Ok(Self {
-            entries,
-            descriptor_set_bindings,
-        })
+        Ok(Self { entries })
     }
 }
 
@@ -451,6 +422,7 @@ impl RenderingOptionOverrides {
 
 pub struct Code {
     pub push_constant_buffer_size_bytes: usize,
+    pub descriptor_set_bindings: Vec<DescriptorTypeVk>,
     pub vertex_semantic_to_location: Vec<(VertexInputSemantic, u32)>,
     pub vertex_entry_point_name: Option<String>,
     pub fragment_entry_point_name: Option<String>,
@@ -461,6 +433,12 @@ impl Code {
         let mut writes = 0;
 
         writes += VariableUInt(self.push_constant_buffer_size_bytes as _).write(sink)?;
+
+        writes += VariableUInt(self.descriptor_set_bindings.len() as _).write(sink)?;
+        for t in self.descriptor_set_bindings.iter() {
+            writes += t.write(sink)?;
+        }
+
         writes += VariableUInt(self.vertex_semantic_to_location.len() as _).write(sink)?;
         for (n, l) in self.vertex_semantic_to_location.iter() {
             writes += n.write(sink)?;
@@ -493,6 +471,15 @@ impl Code {
 
     pub fn read(source: &mut impl BufRead) -> std::io::Result<Self> {
         let push_constant_buffer_size_bytes = VariableUInt::read(source)?.0 as usize;
+
+        let descriptor_set_binding_count = VariableUInt::read(source)?.0 as usize;
+        let mut descriptor_set_bindings = Vec::with_capacity(descriptor_set_binding_count);
+        for _ in 0..descriptor_set_binding_count {
+            let t = DescriptorTypeVk::read(source)?;
+
+            descriptor_set_bindings.push(t);
+        }
+
         let vertex_semantic_to_location_count = VariableUInt::read(source)?.0 as usize;
         let mut vertex_semantic_to_location = Vec::with_capacity(vertex_semantic_to_location_count);
         for _ in 0..vertex_semantic_to_location_count {
@@ -528,6 +515,7 @@ impl Code {
 
         Ok(Self {
             push_constant_buffer_size_bytes,
+            descriptor_set_bindings,
             vertex_semantic_to_location,
             vertex_entry_point_name,
             fragment_entry_point_name,
@@ -540,6 +528,16 @@ impl Code {
     ) -> std::io::Result<Self> {
         let push_constant_buffer_size_bytes =
             VariableUInt::read_async(source.as_mut()).await?.0 as usize;
+
+        let VariableUInt(descriptor_set_binding_count) =
+            VariableUInt::read_async(source.as_mut()).await?;
+        let mut descriptor_set_bindings = Vec::with_capacity(descriptor_set_binding_count as _);
+        for _ in 0..descriptor_set_binding_count {
+            let t = DescriptorTypeVk::read_async(source.as_mut()).await?;
+
+            descriptor_set_bindings.push(t);
+        }
+
         let vertex_semantic_to_location_count =
             VariableUInt::read_async(source.as_mut()).await?.0 as usize;
         let mut vertex_semantic_to_location = Vec::with_capacity(vertex_semantic_to_location_count);
@@ -576,6 +574,7 @@ impl Code {
 
         Ok(Self {
             push_constant_buffer_size_bytes,
+            descriptor_set_bindings,
             vertex_semantic_to_location,
             vertex_entry_point_name,
             fragment_entry_point_name,

--- a/modules/rendering-configuration/src/lib.rs
+++ b/modules/rendering-configuration/src/lib.rs
@@ -18,7 +18,6 @@ mod file;
 pub struct CompiledRenderingConfigurationVk {
     pub property_mappings: HashMap<String, (PropertyType, PropertyMappingVk)>,
     pub descriptor_set_bindings: Vec<DescriptorTypeVk>,
-    pub push_constant_buffer_size_bytes: usize,
     pub passes: HashMap<String, ShadingPassVk>,
 }
 
@@ -123,6 +122,7 @@ impl Default for VariantKey {
 }
 
 pub struct Code {
+    pub push_constant_buffer_size_bytes: usize,
     pub vertex_semantic_to_location: HashMap<VertexInputSemantic, u32>,
     pub vertex_entry_point_name: Option<String>,
     pub fragment_entry_point_name: Option<String>,
@@ -271,7 +271,6 @@ pub fn write(
             .map(|(n, (t, m))| (n, t, m))
             .collect(),
         descriptor_set_bindings: compiled.descriptor_set_bindings,
-        push_constant_buffer_size_bytes: compiled.push_constant_buffer_size_bytes,
     }
     .write(sink)?;
 
@@ -301,6 +300,8 @@ pub fn write(
                             (
                                 k,
                                 file::Code {
+                                    push_constant_buffer_size_bytes: v
+                                        .push_constant_buffer_size_bytes,
                                     vertex_semantic_to_location: v
                                         .vertex_semantic_to_location
                                         .into_iter()
@@ -352,7 +353,6 @@ pub async fn read_async(
     let mut result = CompiledRenderingConfigurationVk {
         property_mappings: HashMap::with_capacity(property_directory.entries.len()),
         descriptor_set_bindings: property_directory.descriptor_set_bindings,
-        push_constant_buffer_size_bytes: property_directory.push_constant_buffer_size_bytes,
         passes: HashMap::with_capacity(shading_pass_directory.entries.len()),
     };
     for (n, t, m) in property_directory.entries {
@@ -399,6 +399,8 @@ pub async fn read_async(
                         match variants.entry(k) {
                             std::collections::hash_map::Entry::Vacant(x) => {
                                 x.insert(Code {
+                                    push_constant_buffer_size_bytes: v
+                                        .push_constant_buffer_size_bytes,
                                     vertex_semantic_to_location,
                                     vertex_entry_point_name: v.vertex_entry_point_name,
                                     fragment_entry_point_name: v.fragment_entry_point_name,
@@ -439,7 +441,6 @@ pub fn read(
     let mut result = CompiledRenderingConfigurationVk {
         property_mappings: HashMap::with_capacity(property_directory.entries.len()),
         descriptor_set_bindings: property_directory.descriptor_set_bindings,
-        push_constant_buffer_size_bytes: property_directory.push_constant_buffer_size_bytes,
         passes: HashMap::with_capacity(shading_pass_directory.entries.len()),
     };
     for (n, t, m) in property_directory.entries {
@@ -480,6 +481,8 @@ pub fn read(
                         match variants.entry(k) {
                             std::collections::hash_map::Entry::Vacant(x) => {
                                 x.insert(Code {
+                                    push_constant_buffer_size_bytes: v
+                                        .push_constant_buffer_size_bytes,
                                     vertex_semantic_to_location,
                                     vertex_entry_point_name: v.vertex_entry_point_name,
                                     fragment_entry_point_name: v.fragment_entry_point_name,

--- a/modules/rendering-configuration/src/lib.rs
+++ b/modules/rendering-configuration/src/lib.rs
@@ -17,7 +17,6 @@ mod file;
 /// converted asset data
 pub struct CompiledRenderingConfigurationVk {
     pub property_mappings: HashMap<String, (PropertyType, PropertyMappingVk)>,
-    pub descriptor_set_bindings: Vec<DescriptorTypeVk>,
     pub passes: HashMap<String, ShadingPassVk>,
 }
 
@@ -123,6 +122,7 @@ impl Default for VariantKey {
 
 pub struct Code {
     pub push_constant_buffer_size_bytes: usize,
+    pub descriptor_set_bindings: Vec<DescriptorTypeVk>,
     pub vertex_semantic_to_location: HashMap<VertexInputSemantic, u32>,
     pub vertex_entry_point_name: Option<String>,
     pub fragment_entry_point_name: Option<String>,
@@ -270,7 +270,6 @@ pub fn write(
             .into_iter()
             .map(|(n, (t, m))| (n, t, m))
             .collect(),
-        descriptor_set_bindings: compiled.descriptor_set_bindings,
     }
     .write(sink)?;
 
@@ -302,6 +301,7 @@ pub fn write(
                                 file::Code {
                                     push_constant_buffer_size_bytes: v
                                         .push_constant_buffer_size_bytes,
+                                    descriptor_set_bindings: v.descriptor_set_bindings,
                                     vertex_semantic_to_location: v
                                         .vertex_semantic_to_location
                                         .into_iter()
@@ -352,7 +352,6 @@ pub async fn read_async(
 
     let mut result = CompiledRenderingConfigurationVk {
         property_mappings: HashMap::with_capacity(property_directory.entries.len()),
-        descriptor_set_bindings: property_directory.descriptor_set_bindings,
         passes: HashMap::with_capacity(shading_pass_directory.entries.len()),
     };
     for (n, t, m) in property_directory.entries {
@@ -401,6 +400,7 @@ pub async fn read_async(
                                 x.insert(Code {
                                     push_constant_buffer_size_bytes: v
                                         .push_constant_buffer_size_bytes,
+                                    descriptor_set_bindings: v.descriptor_set_bindings,
                                     vertex_semantic_to_location,
                                     vertex_entry_point_name: v.vertex_entry_point_name,
                                     fragment_entry_point_name: v.fragment_entry_point_name,
@@ -440,7 +440,6 @@ pub fn read(
 
     let mut result = CompiledRenderingConfigurationVk {
         property_mappings: HashMap::with_capacity(property_directory.entries.len()),
-        descriptor_set_bindings: property_directory.descriptor_set_bindings,
         passes: HashMap::with_capacity(shading_pass_directory.entries.len()),
     };
     for (n, t, m) in property_directory.entries {
@@ -483,6 +482,7 @@ pub fn read(
                                 x.insert(Code {
                                     push_constant_buffer_size_bytes: v
                                         .push_constant_buffer_size_bytes,
+                                    descriptor_set_bindings: v.descriptor_set_bindings,
                                     vertex_semantic_to_location,
                                     vertex_entry_point_name: v.vertex_entry_point_name,
                                     fragment_entry_point_name: v.fragment_entry_point_name,

--- a/thirdparty/spirv-tools/Cargo.toml
+++ b/thirdparty/spirv-tools/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "spirv-tools"
+description = "KhronosGroup/SPIRV-Tools binding for rust"
+version = "0.1.0"
+edition = "2024"
+build = "build.rs"
+
+[dependencies]
+
+[build-dependencies]
+build-script-helper.path = "../../build-script-helper"

--- a/thirdparty/spirv-tools/build.rs
+++ b/thirdparty/spirv-tools/build.rs
@@ -1,0 +1,55 @@
+use build_script_helper::{
+    peridot_build_skip_cdeps, peridot_build_switch_enable, peridot_build_watch_skip_cdeps,
+};
+
+fn main() {
+    build_cdeps();
+}
+
+fn build_cdeps() {
+    peridot_build_watch_skip_cdeps();
+    if peridot_build_skip_cdeps() {
+        return;
+    }
+
+    let source_repo_path = std::env::current_dir()
+        .expect("current_dir")
+        .join("source-repo");
+
+    if !peridot_build_switch_enable!("TP_SPIRV_TOOLS_SKIP_CMAKE") {
+        let build_dir_path = source_repo_path.join("build");
+        if !build_dir_path.exists() {
+            std::fs::create_dir(&build_dir_path).expect("create_dir for build");
+        }
+
+        let mut cmd = std::process::Command::new("cmake");
+        cmd.current_dir(&build_dir_path).args(&[
+            "-G",
+            "Ninja",
+            "-DSPIRV_SKIP_TESTS=ON",
+            "-DSPIRV_SKIP_EXECUTABLES=ON",
+            "..",
+        ]);
+        let r = cmd.spawn().expect("cmake").wait().expect("wait: cmake");
+        if !r.success() {
+            panic!("cmake prepare failed with exit code {r:?}");
+        }
+
+        let mut cmd = std::process::Command::new("cmake");
+        cmd.current_dir(&build_dir_path).args(&["--build", "."]);
+        let r = cmd
+            .spawn()
+            .expect("cmake build")
+            .wait()
+            .expect("wait: cmake build");
+        if !r.success() {
+            panic!("cmake build failed with exit code {r:?}");
+        }
+    }
+
+    println!(
+        "cargo::rustc-link-search={}",
+        source_repo_path.join("build/source").display()
+    );
+    println!("cargo::rustc-link-lib=SPIRV-Tools-shared");
+}

--- a/thirdparty/spirv-tools/src/ffi.rs
+++ b/thirdparty/spirv-tools/src/ffi.rs
@@ -1,0 +1,416 @@
+#![allow(non_camel_case_types, non_upper_case_globals)]
+
+use core::ffi::*;
+
+pub type spv_result_t = i32;
+pub const SPV_SUCCESS: spv_result_t = 0;
+pub const SPV_UNSUPPORTED: spv_result_t = 1;
+pub const SPV_END_OF_STREAM: spv_result_t = 2;
+pub const SPV_WARNING: spv_result_t = 3;
+pub const SPV_FAILED_MATCH: spv_result_t = 4;
+pub const SPV_REQUESTED_TERMINATION: spv_result_t = 5;
+pub const SPV_ERROR_INTERNAL: spv_result_t = -1;
+pub const SPV_ERROR_OUT_OF_MEMORY: spv_result_t = -2;
+pub const SPV_ERROR_INVALID_POINTER: spv_result_t = -3;
+pub const SPV_ERROR_INVALID_BINARY: spv_result_t = -4;
+pub const SPV_ERROR_INVALID_TEXT: spv_result_t = -5;
+pub const SPV_ERROR_INVALID_TABLE: spv_result_t = -6;
+pub const SPV_ERROR_INVALID_VALUE: spv_result_t = -7;
+pub const SPV_ERROR_INVALID_DIAGNOSTIC: spv_result_t = -8;
+pub const SPV_ERROR_INVALID_LOOKUP: spv_result_t = -9;
+pub const SPV_ERROR_INVALID_ID: spv_result_t = -10;
+pub const SPV_ERROR_INVALID_CFG: spv_result_t = -11;
+pub const SPV_ERROR_INVALID_LAYOUT: spv_result_t = -12;
+pub const SPV_ERROR_INVALID_CAPABILITY: spv_result_t = -13;
+pub const SPV_ERROR_INVALID_DATA: spv_result_t = -14;
+pub const SPV_ERROR_MISSING_EXTENSION: spv_result_t = -15;
+pub const SPV_ERROR_WRONG_VERSION: spv_result_t = -16;
+pub const SPV_ERROR_FNVAR: spv_result_t = -17;
+
+pub type spv_message_level_t = c_int;
+pub const SPV_MSG_FATAL: spv_message_level_t = 0;
+pub const SPV_MSG_INTERNAL_ERROR: spv_message_level_t = 1;
+pub const SPV_MSG_ERROR: spv_message_level_t = 2;
+pub const SPV_MSG_WARNING: spv_message_level_t = 3;
+pub const SPV_MSG_INFO: spv_message_level_t = 4;
+pub const SPV_MSG_DEBUG: spv_message_level_t = 5;
+
+pub type spv_endianness_t = i32;
+pub const SPV_ENDIANNESS_LITTLE: spv_endianness_t = 0;
+pub const SPV_ENDIANNESS_BIG: spv_endianness_t = 1;
+
+pub type spv_operand_type_t = u32;
+
+unsafe extern "C" {
+    pub fn spvOperandIsConcrete(r#type: spv_operand_type_t) -> bool;
+    pub fn spvOperandIsConcreteMask(r#type: spv_operand_type_t) -> bool;
+}
+
+pub type spv_ext_inst_type_t = u32;
+
+pub type spv_number_kind_t = c_int;
+pub const SPV_NUMBER_NONE: spv_number_kind_t = 0;
+pub const SPV_NUMBER_UNSIGNED_INT: spv_number_kind_t = 1;
+pub const SPV_NUMBER_SIGNED_INT: spv_number_kind_t = 2;
+pub const SPV_NUMBER_FLOATING: spv_number_kind_t = 3;
+
+pub type spv_fp_encoding_t = c_int;
+pub const SPV_FP_ENCODING_UNKNOWN: spv_fp_encoding_t = 0;
+pub const SPV_FP_ENCODING_IEEE754_BINARY16: spv_fp_encoding_t = 1;
+pub const SPV_FP_ENCODING_IEEE754_BINARY32: spv_fp_encoding_t = 2;
+pub const SPV_FP_ENCODING_IEEE754_BINARY64: spv_fp_encoding_t = 3;
+pub const SPV_FP_ENCODING_BFLOAT16: spv_fp_encoding_t = 4;
+pub const SPV_FP_ENCODING_FLOAT8_E4M3: spv_fp_encoding_t = 5;
+pub const SPV_FP_ENCODING_FLOAT8_E5M2: spv_fp_encoding_t = 6;
+
+pub type spv_text_to_binary_options_t = u32;
+pub const SPV_TEXT_TO_BINARY_OPTION_NONE: spv_text_to_binary_options_t = 1 << 0;
+pub const SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS: spv_text_to_binary_options_t = 1 << 1;
+
+pub type spv_binary_to_text_options_t = u32;
+pub const SPV_BINARY_TO_TEXT_OPTION_NONE: spv_binary_to_text_options_t = 1 << 0;
+pub const SPV_BINARY_TO_TEXT_OPTION_PRINT: spv_binary_to_text_options_t = 1 << 1;
+pub const SPV_BINARY_TO_TEXT_OPTION_COLOR: spv_binary_to_text_options_t = 1 << 2;
+pub const SPV_BINARY_TO_TEXT_OPTION_INDENT: spv_binary_to_text_options_t = 1 << 3;
+pub const SPV_BINARY_TO_TEXT_OPTION_SHOW_BYTE_OFFSET: spv_binary_to_text_options_t = 1 << 4;
+pub const SPV_BINARY_TO_TEXT_OPTION_NO_HEADER: spv_binary_to_text_options_t = 1 << 5;
+pub const SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES: spv_binary_to_text_options_t = 1 << 6;
+pub const SPV_BINARY_TO_TEXT_OPTION_COMMENT: spv_binary_to_text_options_t = 1 << 7;
+pub const SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT: spv_binary_to_text_options_t = 1 << 8;
+pub const SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS: spv_binary_to_text_options_t = 1 << 9;
+
+pub const kDefaultMaxIdBound: u32 = 0x3fffff;
+
+#[repr(C)]
+pub struct spv_parsed_operand_t {
+    pub offset: u16,
+    pub num_words: u16,
+    pub r#type: spv_operand_type_t,
+    pub number_kind: spv_number_kind_t,
+    pub number_bit_width: u32,
+    pub fp_encoding: spv_fp_encoding_t,
+}
+
+#[repr(C)]
+pub struct spv_parsed_instruction_t {
+    pub words: *const u32,
+    pub num_words: u16,
+    pub opcode: u16,
+    pub ext_inst_type: spv_ext_inst_type_t,
+    pub type_id: u32,
+    pub result_id: u32,
+    pub operands: *const spv_parsed_operand_t,
+    pub num_operands: u16,
+}
+
+#[repr(C)]
+pub struct spv_parsed_header_t {
+    pub magic: u32,
+    pub version: u32,
+    pub generator: u32,
+    pub bound: u32,
+    pub reserved: u32,
+}
+
+#[repr(C)]
+pub struct spv_const_binary_t {
+    pub code: *const u32,
+    pub word_count: usize,
+}
+
+#[repr(C)]
+pub struct spv_binary_t {
+    pub code: *mut u32,
+    pub word_count: usize,
+}
+
+#[repr(C)]
+pub struct spv_text_t {
+    pub str: *const c_char,
+    pub length: usize,
+}
+
+#[repr(C)]
+pub struct spv_position_t {
+    pub line: usize,
+    pub column: usize,
+    pub index: usize,
+}
+
+#[repr(C)]
+pub struct spv_diagnostic_t {
+    pub position: spv_position_t,
+    pub error: *mut c_char,
+    pub is_text_source: bool,
+}
+
+#[repr(C)]
+struct OpaqueFFIStruct(
+    [u8; 0],
+    core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+);
+
+#[repr(C)]
+pub struct spv_context_t(OpaqueFFIStruct);
+
+#[repr(C)]
+pub struct spv_validator_options_t(OpaqueFFIStruct);
+
+#[repr(C)]
+pub struct spv_optimizer_options_t(OpaqueFFIStruct);
+
+#[repr(C)]
+pub struct spv_reducer_options_t(OpaqueFFIStruct);
+
+#[repr(C)]
+pub struct spv_fuzzer_options_t(OpaqueFFIStruct);
+
+#[repr(C)]
+pub struct spv_optimizer_t(OpaqueFFIStruct);
+
+unsafe extern "C" {
+    pub fn spvSoftwareVersionString() -> *const c_char;
+    pub fn spvSoftwareVersionDetailsString() -> *const c_char;
+}
+
+pub type spv_target_env = c_int;
+pub const SPV_ENV_UNIVERSAL_1_0: spv_target_env = 0;
+pub const SPV_ENV_VULKAN_1_0: spv_target_env = 1;
+pub const SPV_ENV_UNIVERSAL_1_1: spv_target_env = 2;
+pub const SPV_ENV_OPENCL_2_1: spv_target_env = 3;
+pub const SPV_ENV_OPENCL_2_2: spv_target_env = 4;
+pub const SPV_ENV_OPENGL_4_0: spv_target_env = 5;
+pub const SPV_ENV_OPENGL_4_1: spv_target_env = 6;
+pub const SPV_ENV_OPENGL_4_2: spv_target_env = 7;
+pub const SPV_ENV_OPENGL_4_3: spv_target_env = 8;
+pub const SPV_ENV_OPENGL_4_5: spv_target_env = 9;
+pub const SPV_ENV_UNIVERSAL_1_2: spv_target_env = 10;
+pub const SPV_ENV_OPENCL_1_2: spv_target_env = 11;
+pub const SPV_ENV_OPENCL_EMBEDDED_1_2: spv_target_env = 12;
+pub const SPV_ENV_OPENCL_2_0: spv_target_env = 13;
+pub const SPV_ENV_OPENCL_EMBEDDED_2_0: spv_target_env = 14;
+pub const SPV_ENV_OPENCL_EMBEDDED_2_1: spv_target_env = 15;
+pub const SPV_ENV_OPENCL_EMBEDDED_2_2: spv_target_env = 16;
+pub const SPV_ENV_UNIVERSAL_1_3: spv_target_env = 17;
+pub const SPV_ENV_VULKAN_1_1: spv_target_env = 18;
+pub const SPV_ENV_WEBGPU_0: spv_target_env = 19;
+pub const SPV_ENV_UNIVERSAL_1_4: spv_target_env = 20;
+pub const SPV_ENV_VULKAN_1_1_SPIRV_1_4: spv_target_env = 21;
+pub const SPV_ENV_UNIVERSAL_1_5: spv_target_env = 22;
+pub const SPV_ENV_VULKAN_1_2: spv_target_env = 23;
+pub const SPV_ENV_UNIVERSAL_1_6: spv_target_env = 24;
+pub const SPV_ENV_VULKAN_1_3: spv_target_env = 25;
+pub const SPV_ENV_VULKAN_1_4: spv_target_env = 26;
+
+pub type spv_validator_limit = c_int;
+pub const spv_validator_limit_max_struct_members: spv_validator_limit = 0;
+pub const spv_validator_limit_max_struct_depth: spv_validator_limit = 1;
+pub const spv_validator_limit_max_local_variables: spv_validator_limit = 2;
+pub const spv_validator_limit_max_global_variables: spv_validator_limit = 3;
+pub const spv_validator_limit_max_switch_branches: spv_validator_limit = 4;
+pub const spv_validator_limit_max_function_args: spv_validator_limit = 5;
+pub const spv_validator_limit_max_control_flow_nesting_depth: spv_validator_limit = 6;
+pub const spv_validator_limit_max_access_chain_indexes: spv_validator_limit = 7;
+pub const spv_validator_limit_max_id_bound: spv_validator_limit = 8;
+
+unsafe extern "C" {
+    pub fn spvTargetEnvDescription(env: spv_target_env) -> *const c_char;
+    pub fn spvParseTargetEnv(s: *const c_char, env: *mut spv_target_env) -> bool;
+    pub fn spvParseVulkanEnv(vulkan_ver: u32, spirv_ver: u32, env: *mut spv_target_env) -> bool;
+    pub fn spvContextCreate(env: spv_target_env) -> *mut spv_context_t;
+    pub fn spvContextDestroy(context: *mut spv_context_t);
+
+    pub fn spvValidatorOptionsCreate() -> *mut spv_validator_options_t;
+    pub fn spvValidatorOptionsDestroy(options: *mut spv_validator_options_t);
+    pub fn spvValidatorOptionsSetUniversalLimit(
+        options: *mut spv_validator_options_t,
+        limit_type: spv_validator_limit,
+        limit: u32,
+    );
+    pub fn spvValidatorOptionsSetRelaxStoreStruct(options: *mut spv_validator_options_t, val: bool);
+    pub fn spvValidatorOptionsSetRelaxLogicalPointer(
+        options: *mut spv_validator_options_t,
+        val: bool,
+    );
+    pub fn spvValidatorOptionsSetBeforeHlslLegalization(
+        options: *mut spv_validator_options_t,
+        val: bool,
+    );
+    pub fn spvValidatorOptionsSetRelaxBlockLayout(options: *mut spv_validator_options_t, val: bool);
+    pub fn spvValidatorOptionsSetUniformBufferStandardLayout(
+        options: *mut spv_validator_options_t,
+        val: bool,
+    );
+    pub fn spvValidatorOptionsSetScalarBlockLayout(
+        options: *mut spv_validator_options_t,
+        val: bool,
+    );
+    pub fn spvValidatorOptionsSetWorkgroupScalarBlockLayout(
+        options: *mut spv_validator_options_t,
+        val: bool,
+    );
+    pub fn spvValidatorOptionsSetSkipBlockLayout(options: *mut spv_validator_options_t, val: bool);
+    pub fn spvValidatorOptionsSetAllowLocalSizeId(options: *mut spv_validator_options_t, val: bool);
+    pub fn spvValidatorOptionsSetAllowOffsetTextureOperand(
+        options: *mut spv_validator_options_t,
+        val: bool,
+    );
+    pub fn spvValidatorOptionsSetAllowVulkan32BitBitwise(
+        options: *mut spv_validator_options_t,
+        val: bool,
+    );
+    pub fn spvValidatorOptionsSetFriendlyNames(options: *mut spv_validator_options_t, val: bool);
+
+    pub fn spvOptimizerOptionsCreate() -> *mut spv_optimizer_options_t;
+    pub fn spvOptimizerOptionsDestroy(options: *mut spv_optimizer_options_t);
+    pub fn spvOptimizerOptionsSetRunValidator(options: *mut spv_optimizer_options_t, val: bool);
+    pub fn spvOptimizerOptionsSetValidatorOptions(
+        options: *mut spv_optimizer_options_t,
+        val: *mut spv_validator_options_t,
+    );
+    pub fn spvOptimizerOptionsSetMaxIdBound(options: *mut spv_optimizer_options_t, val: u32);
+    pub fn spvoptimizerOptionsSetPreserveBindings(options: *mut spv_optimizer_options_t, val: bool);
+    pub fn spvOptimizerOptionsSetPreserveSpecConstants(
+        options: *mut spv_optimizer_options_t,
+        val: bool,
+    );
+
+    pub fn spvReducerOptionsCreate() -> *mut spv_reducer_options_t;
+    pub fn spvReducerOptionsDestroy(options: *mut spv_reducer_options_t);
+    pub fn spvReducerOptionsSetStepLimit(options: *mut spv_reducer_options_t, step_limit: u32);
+    pub fn spvReducerOptionsSetFailOnValidationError(
+        options: *mut spv_reducer_options_t,
+        fail_on_validation_error: bool,
+    );
+    pub fn spvReducerOptionsSetTargetFunction(
+        options: *mut spv_reducer_options_t,
+        target_function: u32,
+    );
+
+    pub fn spvFuzzerOptionsCreate() -> *mut spv_fuzzer_options_t;
+    pub fn spvFuzzerOptionsDestroy(options: *mut spv_fuzzer_options_t);
+    pub fn spvFuzzerOptionsEnableReplayValidation(options: *mut spv_fuzzer_options_t);
+    pub fn spvFuzzerOptionsSetRandomSeed(options: *mut spv_fuzzer_options_t, seed: u32);
+    pub fn spvFuzzerOptionsSetReplayRange(options: *mut spv_fuzzer_options_t, replay_range: i32);
+    pub fn spvFuzzerOptionsSetShrinkerStepLimit(
+        options: *mut spv_fuzzer_options_t,
+        shrinker_step_limit: u32,
+    );
+    pub fn spvFuzzerOptionsEnableFuzzerPassValidation(options: *mut spv_fuzzer_options_t);
+    pub fn spvFuzzerOptionsEnableAllPasses(options: *mut spv_fuzzer_options_t);
+
+    pub fn spvTextToBinary(
+        context: *const spv_context_t,
+        text: *const c_char,
+        length: usize,
+        binary: *mut *mut spv_binary_t,
+        diagnostic: *mut *mut spv_diagnostic_t,
+    ) -> spv_result_t;
+    pub fn spvTextToBinaryWithOptions(
+        context: *const spv_context_t,
+        text: *const c_char,
+        length: usize,
+        options: u32,
+        binary: *mut *mut spv_binary_t,
+        diagnostic: *mut *mut spv_diagnostic_t,
+    ) -> spv_result_t;
+    pub fn spvTextDestroy(text: *mut spv_text_t);
+    pub fn spvBinaryToText(
+        context: *const spv_context_t,
+        binary: *const u32,
+        word_count: usize,
+        options: u32,
+        text: *mut *mut spv_text_t,
+        diagnostic: *mut *mut spv_diagnostic_t,
+    ) -> spv_result_t;
+    pub fn spvBinaryDestroy(binary: *mut spv_binary_t);
+    pub fn spvValidate(
+        context: *const spv_context_t,
+        binary: *const spv_binary_t,
+        diagnostic: *mut *mut spv_diagnostic_t,
+    ) -> spv_result_t;
+    pub fn spvValidateWithOptions(
+        context: *const spv_context_t,
+        options: *const spv_validator_options_t,
+        binary: *const spv_binary_t,
+        diagnostic: *mut *mut spv_diagnostic_t,
+    ) -> spv_result_t;
+    pub fn spvValidateBinary(
+        context: *const spv_context_t,
+        words: *const u32,
+        num_words: usize,
+        diagnostic: *mut *mut spv_diagnostic_t,
+    ) -> spv_result_t;
+
+    pub fn spvDiagnosticCreate(
+        position: *mut spv_position_t,
+        message: *const c_char,
+    ) -> *mut spv_diagnostic_t;
+    pub fn spvDiagnosticDestroy(diagnostic: *mut spv_diagnostic_t);
+    pub fn spvDiagnosticPrint(diagnostic: *mut spv_diagnostic_t) -> spv_result_t;
+
+    pub fn spvOpcodeString(opcode: u32) -> *const c_char;
+}
+
+pub type spv_parsed_header_fn_t = extern "C" fn(
+    user_data: *mut c_void,
+    endian: spv_endianness_t,
+    magic: u32,
+    version: u32,
+    generator: u32,
+    id_bound: u32,
+    reserved: u32,
+) -> spv_result_t;
+
+pub type spv_parsed_instruction_fn_t = extern "C" fn(
+    user_data: *mut c_void,
+    parsed_instruction: *const spv_parsed_instruction_t,
+) -> spv_result_t;
+
+unsafe extern "C" {
+    pub fn spvBinaryParse(
+        context: *const spv_context_t,
+        user_data: *mut c_void,
+        words: *const u32,
+        num_words: usize,
+        parse_header: Option<spv_parsed_header_fn_t>,
+        parse_instruction: Option<spv_parsed_instruction_fn_t>,
+        diagnostic: *mut *mut spv_diagnostic_t,
+    ) -> spv_result_t;
+}
+
+pub type spv_message_consumer =
+    extern "C" fn(spv_message_level_t, *const c_char, *const spv_position_t, *const c_char);
+
+unsafe extern "C" {
+    pub fn spvOptimizerCreate(env: spv_target_env) -> *mut spv_optimizer_t;
+    pub fn spvOptimizerDestroy(optimizer: *mut spv_optimizer_t);
+    pub fn spvOptimizerSetMessageConsumer(
+        optimizer: *mut spv_optimizer_t,
+        consumer: spv_message_consumer,
+    );
+    pub fn spvOptimizerRegisterLegalizationPasses(optimizer: *mut spv_optimizer_t);
+    pub fn spvOptimizerRegisterPerformancePasses(optimizer: *mut spv_optimizer_t);
+    pub fn spvOptimizerRegisterSizePasses(optimiezr: *mut spv_optimizer_t);
+    pub fn spvOptimizerRegisterPassFromFlag(
+        optimizer: *mut spv_optimizer_t,
+        flag: *const c_char,
+    ) -> bool;
+    pub fn spvOptimizerRegisterPassesFromFlags(
+        optimizer: *mut spv_optimizer_t,
+        flags: *mut *const c_char,
+        flag_count: usize,
+    ) -> bool;
+    pub fn spvOptimizerRegisterPassesFromFlagsWhilePreservingTheInterface(
+        optimizer: *mut spv_optimizer_t,
+        flags: *mut *const c_char,
+        flag_count: usize,
+    ) -> bool;
+    pub fn spvOptimizerRun(
+        optimizer: *mut spv_optimizer_t,
+        binary: *const u32,
+        word_count: usize,
+        optimized_binary: *mut *mut spv_binary_t,
+        options: *mut spv_optimizer_options_t,
+    ) -> spv_result_t;
+}

--- a/thirdparty/spirv-tools/src/lib.rs
+++ b/thirdparty/spirv-tools/src/lib.rs
@@ -1,0 +1,56 @@
+use core::ptr::NonNull;
+
+pub mod ffi;
+
+#[repr(transparent)]
+pub struct Context(NonNull<ffi::spv_context_t>);
+impl Drop for Context {
+    #[inline(always)]
+    fn drop(&mut self) {
+        unsafe { ffi::spvContextDestroy(self.0.as_ptr()) }
+    }
+}
+impl Context {
+    pub fn new(env: ffi::spv_target_env) -> Self {
+        unsafe { Self(NonNull::new_unchecked(ffi::spvContextCreate(env))) }
+    }
+
+    pub fn binary_to_text(
+        &self,
+        binary: &[u32],
+        options: u32,
+        diagnostic: Option<*mut *mut ffi::spv_diagnostic_t>,
+    ) -> Result<Text, ffi::spv_result_t> {
+        let mut p = core::mem::MaybeUninit::uninit();
+        match unsafe {
+            ffi::spvBinaryToText(
+                self.0.as_ptr().cast_const(),
+                binary.as_ptr(),
+                binary.len(),
+                options,
+                p.as_mut_ptr(),
+                diagnostic.unwrap_or_else(core::ptr::null_mut),
+            )
+        } {
+            r if r == ffi::SPV_SUCCESS => {
+                Ok(unsafe { Text(NonNull::new_unchecked(p.assume_init())) })
+            }
+            r => Err(r),
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct Text(NonNull<ffi::spv_text_t>);
+impl Drop for Text {
+    #[inline(always)]
+    fn drop(&mut self) {
+        unsafe { ffi::spvTextDestroy(self.0.as_ptr()) }
+    }
+}
+impl Text {
+    #[inline(always)]
+    pub const fn as_cstr(&self) -> &core::ffi::CStr {
+        unsafe { core::ffi::CStr::from_ptr(self.0.as_ref().str) }
+    }
+}

--- a/tools/cli/src/shellutil.rs
+++ b/tools/cli/src/shellutil.rs
@@ -60,7 +60,8 @@ pub fn sh_mirror(
     }
 
     let mut args = vec![
-        "-auz",
+        "-a",
+        "--delete",
         &source,
         target.to_str().expect("invalid sequence in target path"),
     ];


### PR DESCRIPTION
* Push Constant BufferとDescriptor Set Bindingの情報がCodeに移動した(算出方法的にここのほうがいい)
* VertexBindingsブロックの廃止
  * Shader内で`Peridot::VertexInput`属性をつけたパラメータ/構造体を自動的に検知してそこから頂点フォーマットの情報を得る
* SPIRV-Toolsで生成したSPIR-Vを逆アセンブルするようにした
  * パフォーマンスデグレ検知用